### PR TITLE
Refactor exception classes

### DIFF
--- a/src/Error/AbstractException.php
+++ b/src/Error/AbstractException.php
@@ -3,10 +3,10 @@
 namespace Digia\GraphQL\Error;
 
 /**
- * Class BaseException
+ * Class AbstractException
  * @package Digia\GraphQL\Error
  */
-class BaseException extends \Exception
+abstract class AbstractException extends \Exception
 {
 
 }

--- a/src/Error/BaseException.php
+++ b/src/Error/BaseException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Digia\GraphQL\Error;
+
+/**
+ * Class BaseException
+ * @package Digia\GraphQL\Error
+ */
+class BaseException extends \Exception
+{
+
+}

--- a/src/Error/ExecutionException.php
+++ b/src/Error/ExecutionException.php
@@ -6,12 +6,12 @@ use Digia\GraphQL\Language\AST\Node\NodeInterface;
 use Digia\GraphQL\Language\Source;
 
 /**
- * A GraphQLError describes an Error found during the parse, validate, or
- * execute phases of performing a GraphQL operation. In addition to a message
+ * An ExecutionException describes an exception thrown during the execute
+ * phase of performing a GraphQL operation. In addition to a message
  * and stack trace, it also includes information about the locations in a
  * GraphQL document and/or execution result that correspond to the Error.
  */
-class GraphQLError extends \Exception
+class ExecutionException extends BaseException
 {
 
     /**
@@ -45,7 +45,7 @@ class GraphQLError extends \Exception
     protected $extensions;
 
     /**
-     * GraphQLError constructor.
+     * ExecutionException constructor.
      *
      * @param string      $message
      * @param array|null  $nodes

--- a/src/Error/ExecutionException.php
+++ b/src/Error/ExecutionException.php
@@ -11,7 +11,7 @@ use Digia\GraphQL\Language\Source;
  * and stack trace, it also includes information about the locations in a
  * GraphQL document and/or execution result that correspond to the Error.
  */
-class ExecutionException extends BaseException
+class ExecutionException extends AbstractException
 {
 
     /**

--- a/src/Error/InvalidTypeException.php
+++ b/src/Error/InvalidTypeException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Digia\GraphQL\Error;
+
+/**
+ * Class InvalidTypeException
+ * @package Digia\GraphQL\Error
+ */
+class InvalidTypeException extends BaseException
+{
+
+}

--- a/src/Error/InvalidTypeException.php
+++ b/src/Error/InvalidTypeException.php
@@ -6,7 +6,7 @@ namespace Digia\GraphQL\Error;
  * Class InvalidTypeException
  * @package Digia\GraphQL\Error
  */
-class InvalidTypeException extends BaseException
+class InvalidTypeException extends AbstractException
 {
 
 }

--- a/src/Error/InvariantException.php
+++ b/src/Error/InvariantException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Digia\GraphQL\Error;
+
+/**
+ * Class InvariantException
+ * @package Digia\GraphQL\Error
+ */
+class InvariantException extends BaseException
+{
+
+}

--- a/src/Error/InvariantException.php
+++ b/src/Error/InvariantException.php
@@ -6,7 +6,7 @@ namespace Digia\GraphQL\Error;
  * Class InvariantException
  * @package Digia\GraphQL\Error
  */
-class InvariantException extends BaseException
+class InvariantException extends AbstractException
 {
 
 }

--- a/src/Error/LanguageException.php
+++ b/src/Error/LanguageException.php
@@ -6,7 +6,7 @@ namespace Digia\GraphQL\Error;
  * Class LanguageException
  * @package Digia\GraphQL\Error
  */
-class LanguageException extends BaseException
+class LanguageException extends AbstractException
 {
 
 }

--- a/src/Error/LanguageException.php
+++ b/src/Error/LanguageException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Digia\GraphQL\Error;
+
+/**
+ * Class LanguageException
+ * @package Digia\GraphQL\Error
+ */
+class LanguageException extends BaseException
+{
+
+}

--- a/src/Error/SyntaxError.php
+++ b/src/Error/SyntaxError.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Digia\GraphQL\Error;
-
-class SyntaxError extends GraphQLError
-{
-
-}

--- a/src/Error/SyntaxErrorException.php
+++ b/src/Error/SyntaxErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Digia\GraphQL\Error;
+
+/**
+ * Class SyntaxErrorException
+ * @package Digia\GraphQL\Error
+ */
+class SyntaxErrorException extends LanguageException
+{
+
+}

--- a/src/Execution/Execution.php
+++ b/src/Execution/Execution.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
 use Digia\GraphQL\Language\AST\NodeKindEnum;
 use Digia\GraphQL\Type\Schema;
@@ -60,7 +60,7 @@ class Execution
                 $operationName,
                 $fieldResolver
             );
-        } catch (GraphQLError $error) {
+        } catch (ExecutionException $error) {
             return new ExecutionResult(['data' => null], [$error]);
         }
 

--- a/src/Execution/ExecutionContext.php
+++ b/src/Execution/ExecutionContext.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Language\AST\Node\FragmentDefinitionNode;
 use Digia\GraphQL\Language\AST\Node\OperationDefinitionNode;
 use Digia\GraphQL\Type\Schema;
@@ -45,7 +45,7 @@ class ExecutionContext
     protected $operation;
 
     /**
-     * @var GraphQLError[]
+     * @var ExecutionException[]
      */
     protected $errors;
 
@@ -189,17 +189,17 @@ class ExecutionContext
     }
 
     /**
-     * @param GraphQLError $error
+     * @param ExecutionException $error
      * @return ExecutionContext
      */
-    public function addError(GraphQLError $error)
+    public function addError(ExecutionException $error)
     {
         $this->errors[] = $error;
         return $this;
     }
 
     /**
-     * @return array|GraphQLError[]
+     * @return array|ExecutionException[]
      */
     public function getErrors()
     {

--- a/src/Execution/ExecutionContextBuilder.php
+++ b/src/Execution/ExecutionContextBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
 use Digia\GraphQL\Language\AST\NodeKindEnum;
 use Digia\GraphQL\Type\Schema;
@@ -21,8 +21,8 @@ class ExecutionContextBuilder
      * @param               $rawVariableValues
      * @param null          $operationName
      * @param callable|null $fieldResolver
-     * @throws GraphQLError
      * @return ExecutionContext
+     * @throws ExecutionException
      */
     public function buildContext(
         Schema $schema,
@@ -43,7 +43,7 @@ class ExecutionContextBuilder
             switch ($definition->getKind()) {
                 case NodeKindEnum::OPERATION_DEFINITION:
                     if (!$operationName && $operation) {
-                        throw new GraphQLError(
+                        throw new ExecutionException(
                             'Must provide operation name if query contains multiple operations.'
                         );
                     }
@@ -57,7 +57,7 @@ class ExecutionContextBuilder
                     $fragments[$definition->getName()->getValue()] = $definition;
                     break;
                 default:
-                    throw new GraphQLError(
+                    throw new ExecutionException(
                         "GraphQL cannot execute a request containing a {$definition->getKind()}."
                     );
             }

--- a/src/Execution/ExecutionResult.php
+++ b/src/Execution/ExecutionResult.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Util\SerializationInterface;
 use function Digia\GraphQL\Util\jsonEncode;
 
@@ -10,7 +10,7 @@ class ExecutionResult implements SerializationInterface
 {
 
     /**
-     * @var GraphQLError[]
+     * @var ExecutionException[]
      */
     protected $errors;
 
@@ -21,8 +21,8 @@ class ExecutionResult implements SerializationInterface
 
     /**
      * ExecutionResult constructor.
-     * @param mixed[]        $data
-     * @param GraphQLError[] $errors
+     * @param mixed[]              $data
+     * @param ExecutionException[] $errors
      */
     public function __construct(array $data, array $errors)
     {
@@ -39,7 +39,7 @@ class ExecutionResult implements SerializationInterface
     }
 
     /**
-     * @return array|GraphQLError[]
+     * @return array|ExecutionException[]
      */
     public function getErrors(): array
     {
@@ -47,10 +47,10 @@ class ExecutionResult implements SerializationInterface
     }
 
     /**
-     * @param GraphQLError $error
+     * @param ExecutionException $error
      * @return ExecutionResult
      */
-    public function addError(GraphQLError $error): ExecutionResult
+    public function addError(ExecutionException $error): ExecutionResult
     {
         $this->errors[] = $error;
         return $this;

--- a/src/Execution/ExecutionStrategy.php
+++ b/src/Execution/ExecutionStrategy.php
@@ -142,7 +142,6 @@ abstract class ExecutionStrategy
      * @return array
      *
      * @throws GraphQLError|\Exception
-     * @throws \TypeError
      */
     protected function executeFields(
         ObjectType $parentType,
@@ -174,7 +173,6 @@ abstract class ExecutionStrategy
      * @param string     $fieldName
      * @return Field|null
      * @throws \Exception
-     * @throws \TypeError
      */
     public function getFieldDefinition(Schema $schema, ObjectType $parentType, string $fieldName)
     {
@@ -209,7 +207,6 @@ abstract class ExecutionStrategy
      * @return mixed
      *
      * @throws GraphQLError|\Exception
-     * @throws \TypeError
      */
     protected function resolveField(
         ObjectType $parentType,
@@ -337,7 +334,6 @@ abstract class ExecutionStrategy
      * @return array|\stdClass
      * @throws GraphQLError
      * @throws \Exception
-     * @throws \TypeError
      */
     private function collectAndExecuteSubFields(
         ObjectType $returnType,

--- a/src/Execution/ExecutionStrategy.php
+++ b/src/Execution/ExecutionStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\ExecutionException;
+use Digia\GraphQL\Error\InvalidTypeException;
 use Digia\GraphQL\Execution\Resolver\ResolveInfo;
 use Digia\GraphQL\Language\AST\Node\FieldNode;
 use Digia\GraphQL\Language\AST\Node\FragmentDefinitionNode;
@@ -70,7 +70,6 @@ abstract class ExecutionStrategy
      * @param                  $fields
      * @param                  $visitedFragmentNames
      * @return \ArrayObject
-     * @throws \Exception
      */
     protected function collectFields(
         ObjectType $runtimeType,
@@ -140,8 +139,7 @@ abstract class ExecutionStrategy
      * @param            $fields
      *
      * @return array
-     *
-     * @throws ExecutionException|\Exception
+     * @throws InvalidTypeException
      */
     protected function executeFields(
         ObjectType $parentType,
@@ -171,8 +169,8 @@ abstract class ExecutionStrategy
      * @param Schema     $schema
      * @param ObjectType $parentType
      * @param string     $fieldName
-     * @return Field|null
-     * @throws \Exception
+     * @return \Digia\GraphQL\Type\Definition\Field|null
+     * @throws InvalidTypeException
      */
     public function getFieldDefinition(Schema $schema, ObjectType $parentType, string $fieldName)
     {
@@ -205,8 +203,7 @@ abstract class ExecutionStrategy
      * @param            $path
      *
      * @return mixed
-     *
-     * @throws ExecutionException|\Exception
+     * @throws InvalidTypeException
      */
     protected function resolveField(
         ObjectType $parentType,
@@ -305,7 +302,7 @@ abstract class ExecutionStrategy
      * @param                  $source
      * @param ExecutionContext $context
      * @param ResolveInfo      $info
-     * @return array|\Exception|\Throwable
+     * @return array|\Throwable
      */
     private function resolveOrError(
         Field $field,
@@ -319,8 +316,6 @@ abstract class ExecutionStrategy
             $args = getArgumentValues($field, $fieldNode, $context->getVariableValues());
 
             return $resolveFunction($source, $args, $context, $info);
-        } catch (\Exception $error) {
-            return $error;
         } catch (\Throwable $error) {
             return $error;
         }
@@ -331,9 +326,9 @@ abstract class ExecutionStrategy
      * @param FieldNode[] $fieldNodes
      * @param ResolveInfo $info
      * @param array       $path
+     * @param             $result
      * @return array|\stdClass
-     * @throws ExecutionException
-     * @throws \Exception
+     * @throws InvalidTypeException
      */
     private function collectAndExecuteSubFields(
         ObjectType $returnType,

--- a/src/Execution/ExecutionStrategy.php
+++ b/src/Execution/ExecutionStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Execution\Resolver\ResolveInfo;
 use Digia\GraphQL\Language\AST\Node\FieldNode;
 use Digia\GraphQL\Language\AST\Node\FragmentDefinitionNode;
@@ -141,7 +141,7 @@ abstract class ExecutionStrategy
      *
      * @return array
      *
-     * @throws GraphQLError|\Exception
+     * @throws ExecutionException|\Exception
      */
     protected function executeFields(
         ObjectType $parentType,
@@ -206,7 +206,7 @@ abstract class ExecutionStrategy
      *
      * @return mixed
      *
-     * @throws GraphQLError|\Exception
+     * @throws ExecutionException|\Exception
      */
     protected function resolveField(
         ObjectType $parentType,
@@ -332,7 +332,7 @@ abstract class ExecutionStrategy
      * @param ResolveInfo $info
      * @param array       $path
      * @return array|\stdClass
-     * @throws GraphQLError
+     * @throws ExecutionException
      * @throws \Exception
      */
     private function collectAndExecuteSubFields(

--- a/src/Execution/ExecutorExecutionStrategy.php
+++ b/src/Execution/ExecutorExecutionStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 
 class ExecutorExecutionStrategy extends ExecutionStrategy
 {
@@ -29,7 +29,7 @@ class ExecutorExecutionStrategy extends ExecutionStrategy
 
         } catch (\Exception $ex) {
             $this->context->addError(
-                new GraphQLError($ex->getMessage())
+                new ExecutionException($ex->getMessage())
             );
             return [$ex->getMessage()];
         }

--- a/src/Execution/ExecutorExecutionStrategy.php
+++ b/src/Execution/ExecutorExecutionStrategy.php
@@ -32,11 +32,6 @@ class ExecutorExecutionStrategy extends ExecutionStrategy
                 new GraphQLError($ex->getMessage())
             );
             return [$ex->getMessage()];
-        } catch (\TypeError $ex) {
-            $this->context->addError(
-                new GraphQLError($ex->getMessage())
-            );
-            return [$ex->getMessage()];
         }
 
         return $data;

--- a/src/Execution/Resolver/PropertyFieldResolver.php
+++ b/src/Execution/Resolver/PropertyFieldResolver.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Execution\Resolver;
 
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Execution\ExecutionEnvironment;
 
 class PropertyFieldResolver implements ResolverInterface
@@ -30,6 +31,6 @@ class PropertyFieldResolver implements ResolverInterface
             }
         }
 
-        throw new \Exception(sprintf('Could not resolve value for field "%s".', $fieldName));
+        throw new ExecutionException(sprintf('Could not resolve value for field "%s".', $fieldName));
     }
 }

--- a/src/Execution/Resolver/TypeResolver.php
+++ b/src/Execution/Resolver/TypeResolver.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Execution\Resolver;
 
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Execution\ExecutionEnvironment;
 
 class TypeResolver implements ResolverInterface
@@ -11,7 +12,7 @@ class TypeResolver implements ResolverInterface
      */
     public function resolve(ExecutionEnvironment $environment)
     {
-        $schema    = $environment->getInfo()->getSchema();
+        $schema = $environment->getInfo()->getSchema();
         // TODO: Benchmark
         $className = (new \ReflectionClass($environment->getValue()))->getShortName();
 
@@ -19,6 +20,6 @@ class TypeResolver implements ResolverInterface
             return $type;
         }
 
-        throw new \Exception(sprintf('Could not resolve type for class "%s".', $className));
+        throw new ExecutionException(sprintf('Could not resolve type for class "%s".', $className));
     }
 }

--- a/src/Execution/values.php
+++ b/src/Execution/values.php
@@ -3,10 +3,10 @@
 namespace Digia\GraphQL\Execution;
 
 use Digia\GraphQL\Error\ExecutionException;
+use Digia\GraphQL\Error\InvalidTypeException;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\ArgumentNode;
 use Digia\GraphQL\Language\AST\Node\DirectivesTrait;
-use Digia\GraphQL\Language\AST\Node\DirectiveNode;
-use Digia\GraphQL\Language\AST\Node\FieldNode;
 use Digia\GraphQL\Language\AST\Node\NamedTypeNode;
 use Digia\GraphQL\Language\AST\Node\NodeInterface;
 use Digia\GraphQL\Language\AST\Node\VariableNode;
@@ -23,7 +23,8 @@ use function Digia\GraphQL\Util\keyMap;
  * @param array                                 $variableValues
  * @return array
  * @throws ExecutionException
- * @throws \Exception
+ * @throws InvalidTypeException
+ * @throws InvariantException
  */
 function getArgumentValues($definition, NodeInterface $node, array $variableValues = []): array
 {
@@ -104,7 +105,8 @@ function getArgumentValues($definition, NodeInterface $node, array $variableValu
  * @param array                         $variableValues
  * @return array|null
  * @throws ExecutionException
- * @throws \Exception
+ * @throws InvalidTypeException
+ * @throws InvariantException
  */
 function getDirectiveValues(DirectiveInterface $directive, NodeInterface $node, array $variableValues = []): ?array
 {

--- a/src/Execution/values.php
+++ b/src/Execution/values.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Execution;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Language\AST\Node\ArgumentNode;
 use Digia\GraphQL\Language\AST\Node\DirectivesTrait;
 use Digia\GraphQL\Language\AST\Node\DirectiveNode;
@@ -22,7 +22,7 @@ use function Digia\GraphQL\Util\keyMap;
  * @param FieldNode|DirectiveNode|NodeInterface $node
  * @param array                                 $variableValues
  * @return array
- * @throws GraphQLError
+ * @throws ExecutionException
  * @throws \Exception
  */
 function getArgumentValues($definition, NodeInterface $node, array $variableValues = []): array
@@ -50,7 +50,7 @@ function getArgumentValues($definition, NodeInterface $node, array $variableValu
             if (null === $defaultValue) {
                 $coercedValues[$name] = $defaultValue;
             } elseif (!$argumentType instanceof NonNullType) {
-                throw new GraphQLError(
+                throw new ExecutionException(
                     sprintf('Argument "%s" of required type "%s" was not provided.', $name, $argumentType),
                     [$node]
                 );
@@ -66,7 +66,7 @@ function getArgumentValues($definition, NodeInterface $node, array $variableValu
             } elseif (null !== $defaultValue) {
                 $coercedValues[$name] = $defaultValue;
             } elseif ($argumentType instanceof NonNullType) {
-                throw new GraphQLError(
+                throw new ExecutionException(
                     sprintf(
                         'Argument "%s" of required type "%s" was provided the variable "%s" which was not provided a runtime value.',
                         $name,
@@ -85,7 +85,7 @@ function getArgumentValues($definition, NodeInterface $node, array $variableValu
                 // Note: ValuesOfCorrectType validation should catch this before
                 // execution. This is a runtime check to ensure execution does not
                 // continue with an invalid argument value.
-                throw new GraphQLError(
+                throw new ExecutionException(
                     sprintf('Argument "%s" has invalid value %s.', $name, $valueNode),
                     [$argumentNode->getValue()]
                 );
@@ -103,7 +103,7 @@ function getArgumentValues($definition, NodeInterface $node, array $variableValu
  * @param NodeInterface|DirectivesTrait $node
  * @param array                         $variableValues
  * @return array|null
- * @throws GraphQLError
+ * @throws ExecutionException
  * @throws \Exception
  */
 function getDirectiveValues(DirectiveInterface $directive, NodeInterface $node, array $variableValues = []): ?array

--- a/src/Language/AST/Builder/NodeBuilder.php
+++ b/src/Language/AST/Builder/NodeBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Language\AST\Builder;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\LanguageException;
 use Digia\GraphQL\Language\AST\Node\NodeInterface;
 
 class NodeBuilder implements NodeBuilderInterface, DirectorInterface
@@ -30,12 +30,12 @@ class NodeBuilder implements NodeBuilderInterface, DirectorInterface
     /**
      * @param array $ast
      * @return NodeInterface
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     public function build(array $ast): NodeInterface
     {
         if (!isset($ast['kind'])) {
-            throw new GraphQLError(sprintf('Nodes must specify a kind, got %s', json_encode($ast)));
+            throw new LanguageException(sprintf('Nodes must specify a kind, got %s', json_encode($ast)));
         }
 
         $builder = $this->getBuilder($ast['kind']);
@@ -44,7 +44,7 @@ class NodeBuilder implements NodeBuilderInterface, DirectorInterface
             return $builder->build($ast);
         }
 
-        throw new GraphQLError(sprintf('Node of kind "%s" not supported.', $ast['kind']));
+        throw new LanguageException(sprintf('Node of kind "%s" not supported.', $ast['kind']));
     }
 
     /**

--- a/src/Language/AST/Schema/DefinitionBuilder.php
+++ b/src/Language/AST/Schema/DefinitionBuilder.php
@@ -2,6 +2,10 @@
 
 namespace Digia\GraphQL\Language\AST\Schema;
 
+use Digia\GraphQL\Error\ExecutionException;
+use Digia\GraphQL\Error\InvalidTypeException;
+use Digia\GraphQL\Error\InvariantException;
+use Digia\GraphQL\Error\LanguageException;
 use Digia\GraphQL\Language\AST\Node\DirectiveDefinitionNode;
 use Digia\GraphQL\Language\AST\Node\EnumTypeDefinitionNode;
 use Digia\GraphQL\Language\AST\Node\EnumValueDefinitionNode;
@@ -28,7 +32,6 @@ use Digia\GraphQL\Type\Definition\ObjectType;
 use Digia\GraphQL\Type\Definition\ScalarType;
 use Digia\GraphQL\Type\Definition\TypeInterface;
 use Digia\GraphQL\Type\Definition\UnionType;
-use function Digia\GraphQL\Type\introspectionTypes;
 use Psr\SimpleCache\CacheInterface;
 use function Digia\GraphQL\Execution\getDirectiveValues;
 use function Digia\GraphQL\Language\valueFromAST;
@@ -42,6 +45,7 @@ use function Digia\GraphQL\Type\GraphQLNonNull;
 use function Digia\GraphQL\Type\GraphQLObjectType;
 use function Digia\GraphQL\Type\GraphQLScalarType;
 use function Digia\GraphQL\Type\GraphQLUnionType;
+use function Digia\GraphQL\Type\introspectionTypes;
 use function Digia\GraphQL\Type\specifiedScalarTypes;
 use function Digia\GraphQL\Util\keyMap;
 use function Digia\GraphQL\Util\keyValMap;
@@ -102,8 +106,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param NamedTypeNode|TypeDefinitionNodeInterface $node
      * @inheritdoc
-     * @throws \Exception
-     * @throws \Psr\SimpleCache\InvalidArgumentException
      */
     public function buildType(NodeInterface $node): TypeInterface
     {
@@ -144,7 +146,8 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param TypeNodeInterface $typeNode
      * @return TypeInterface
-     * @throws \Exception
+     * @throws InvariantException
+     * @throws InvalidTypeException
      */
     protected function buildWrappedType(TypeNodeInterface $typeNode): TypeInterface
     {
@@ -155,7 +158,9 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param FieldDefinitionNode|InputValueDefinitionNode $node
      * @return array
-     * @throws \Exception
+     * @throws ExecutionException
+     * @throws InvalidTypeException
+     * @throws InvariantException
      */
     protected function buildField($node): array
     {
@@ -171,7 +176,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param array $nodes
      * @return array
-     * @throws \Exception
      */
     protected function buildArguments(array $nodes): array
     {
@@ -194,7 +198,7 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param TypeDefinitionNodeInterface $node
      * @return NamedTypeInterface
-     * @throws \Exception
+     * @throws LanguageException
      */
     protected function buildNamedType(TypeDefinitionNodeInterface $node): NamedTypeInterface
     {
@@ -217,7 +221,7 @@ class DefinitionBuilder implements DefinitionBuilderInterface
             return $this->buildInputObjectType($node);
         }
 
-        throw new \Exception(sprintf('Type kind "%s" not supported.', $node->getKind()));
+        throw new LanguageException(sprintf('Type kind "%s" not supported.', $node->getKind()));
     }
 
     /**
@@ -243,7 +247,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|InputObjectTypeDefinitionNode $node
      * @return array
-     * @throws \Exception
      */
     protected function buildFields($node): array
     {
@@ -332,7 +335,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param InputObjectTypeDefinitionNode $node
      * @return InputObjectType
-     * @throws \Exception
      */
     protected function buildInputObjectType(InputObjectTypeDefinitionNode $node): InputObjectType
     {
@@ -394,7 +396,8 @@ function getNamedTypeNode(TypeNodeInterface $typeNode): NamedTypeNode
  * @param TypeInterface                        $innerType
  * @param NamedTypeInterface|TypeNodeInterface $inputTypeNode
  * @return TypeInterface
- * @throws \Exception
+ * @throws InvariantException
+ * @throws InvalidTypeException
  */
 function buildWrappedType(TypeInterface $innerType, TypeNodeInterface $inputTypeNode): TypeInterface
 {
@@ -412,7 +415,9 @@ function buildWrappedType(TypeInterface $innerType, TypeNodeInterface $inputType
 /**
  * @param NodeInterface|EnumValueDefinitionNode|FieldDefinitionNode $node
  * @return null|string
- * @throws \Exception
+ * @throws InvariantException
+ * @throws ExecutionException
+ * @throws InvalidTypeException
  */
 function getDeprecationReason(NodeInterface $node): ?string
 {

--- a/src/Language/AST/Schema/DefinitionBuilder.php
+++ b/src/Language/AST/Schema/DefinitionBuilder.php
@@ -145,7 +145,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
      * @param TypeNodeInterface $typeNode
      * @return TypeInterface
      * @throws \Exception
-     * @throws \TypeError
      */
     protected function buildWrappedType(TypeNodeInterface $typeNode): TypeInterface
     {
@@ -157,7 +156,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
      * @param FieldDefinitionNode|InputValueDefinitionNode $node
      * @return array
      * @throws \Exception
-     * @throws \TypeError
      */
     protected function buildField($node): array
     {
@@ -173,7 +171,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param array $nodes
      * @return array
-     * @throws \TypeError
      * @throws \Exception
      */
     protected function buildArguments(array $nodes): array
@@ -246,7 +243,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode|InputObjectTypeDefinitionNode $node
      * @return array
-     * @throws \TypeError
      * @throws \Exception
      */
     protected function buildFields($node): array
@@ -336,7 +332,6 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param InputObjectTypeDefinitionNode $node
      * @return InputObjectType
-     * @throws \TypeError
      * @throws \Exception
      */
     protected function buildInputObjectType(InputObjectTypeDefinitionNode $node): InputObjectType
@@ -399,7 +394,6 @@ function getNamedTypeNode(TypeNodeInterface $typeNode): NamedTypeNode
  * @param TypeInterface                        $innerType
  * @param NamedTypeInterface|TypeNodeInterface $inputTypeNode
  * @return TypeInterface
- * @throws \TypeError
  * @throws \Exception
  */
 function buildWrappedType(TypeInterface $innerType, TypeNodeInterface $inputTypeNode): TypeInterface
@@ -418,7 +412,6 @@ function buildWrappedType(TypeInterface $innerType, TypeNodeInterface $inputType
 /**
  * @param NodeInterface|EnumValueDefinitionNode|FieldDefinitionNode $node
  * @return null|string
- * @throws \TypeError
  * @throws \Exception
  */
 function getDeprecationReason(NodeInterface $node): ?string

--- a/src/Language/AST/Schema/SchemaBuilder.php
+++ b/src/Language/AST/Schema/SchemaBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Language\AST\Schema;
 
+use Digia\GraphQL\Error\LanguageException;
 use Digia\GraphQL\Language\AST\Node\DirectiveDefinitionNode;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
 use Digia\GraphQL\Language\AST\Node\NamedTypeNode;
@@ -35,7 +36,7 @@ class SchemaBuilder implements SchemaBuilderInterface
      * @param DocumentNode $documentNode
      * @param array        $options
      * @return SchemaInterface
-     * @throws \Exception
+     * @throws LanguageException
      */
     public function build(DocumentNode $documentNode, array $options = []): SchemaInterface
     {
@@ -47,7 +48,7 @@ class SchemaBuilder implements SchemaBuilderInterface
         foreach ($documentNode->getDefinitions() as $definition) {
             if ($definition instanceof SchemaDefinitionNode) {
                 if ($schemaDefinition) {
-                    throw new \Exception('Must provide only one schema definition.');
+                    throw new LanguageException('Must provide only one schema definition.');
                 }
                 $schemaDefinition = $definition;
                 continue;
@@ -56,7 +57,7 @@ class SchemaBuilder implements SchemaBuilderInterface
             if ($definition instanceof TypeDefinitionNodeInterface) {
                 $typeName = $definition->getNameValue();
                 if (isset($nodeMap[$typeName])) {
-                    throw new \Exception(sprintf('Type "%s" was defined more than once.', $typeName));
+                    throw new LanguageException(sprintf('Type "%s" was defined more than once.', $typeName));
                 }
                 $typeDefinitions[]  = $definition;
                 $nodeMap[$typeName] = $definition;
@@ -125,7 +126,7 @@ class SchemaBuilder implements SchemaBuilderInterface
  * @param SchemaDefinitionNode $schemaDefinition
  * @param array                $nodeMap
  * @return array
- * @throws \Exception
+ * @throws LanguageException
  */
 function getOperationTypes(SchemaDefinitionNode $schemaDefinition, array $nodeMap): array
 {
@@ -134,15 +135,15 @@ function getOperationTypes(SchemaDefinitionNode $schemaDefinition, array $nodeMa
     foreach ($schemaDefinition->getOperationTypes() as $operationTypeDefinition) {
         /** @var TypeNodeInterface|NamedTypeNode $operationType */
         $operationType = $operationTypeDefinition->getType();
-        $typeName  = $operationType->getNameValue();
-        $operation = $operationTypeDefinition->getOperation();
+        $typeName      = $operationType->getNameValue();
+        $operation     = $operationTypeDefinition->getOperation();
 
         if (isset($operationTypes[$typeName])) {
-            throw new \Exception(sprintf('Must provide only one %s type in schema.', $operation));
+            throw new LanguageException(sprintf('Must provide only one %s type in schema.', $operation));
         }
 
         if (!isset($nodeMap[$typeName])) {
-            throw new \Exception(sprintf('Specified %s type %s not found in document.', $operation, $typeName));
+            throw new LanguageException(sprintf('Specified %s type %s not found in document.', $operation, $typeName));
         }
 
         $operationTypes[$operation] = $operationType;

--- a/src/Language/AST/Schema/SchemaBuilder.php
+++ b/src/Language/AST/Schema/SchemaBuilder.php
@@ -36,7 +36,6 @@ class SchemaBuilder implements SchemaBuilderInterface
      * @param array        $options
      * @return SchemaInterface
      * @throws \Exception
-     * @throws \TypeError
      */
     public function build(DocumentNode $documentNode, array $options = []): SchemaInterface
     {

--- a/src/Language/AST/Schema/SchemaBuilderInterface.php
+++ b/src/Language/AST/Schema/SchemaBuilderInterface.php
@@ -11,7 +11,6 @@ interface SchemaBuilderInterface
      * @param DocumentNode $documentNode
      * @param array        $options
      * @return SchemaInterface
-     * @throws \Exception
      */
     public function build(DocumentNode $documentNode, array $options = []): SchemaInterface;
 }

--- a/src/Language/AST/Schema/SchemaBuilderInterface.php
+++ b/src/Language/AST/Schema/SchemaBuilderInterface.php
@@ -12,7 +12,6 @@ interface SchemaBuilderInterface
      * @param array        $options
      * @return SchemaInterface
      * @throws \Exception
-     * @throws \TypeError
      */
     public function build(DocumentNode $documentNode, array $options = []): SchemaInterface;
 }

--- a/src/Language/AST/Visitor/AcceptVisitorTrait.php
+++ b/src/Language/AST/Visitor/AcceptVisitorTrait.php
@@ -29,7 +29,6 @@ trait AcceptVisitorTrait
      * @param NodeInterface|null $parent
      * @param array              $path
      * @return NodeInterface|AcceptVisitorTrait|SerializationInterface|null
-     * @throws VisitorBreak
      */
     public function accept(
         VisitorInterface $visitor,
@@ -108,7 +107,6 @@ trait AcceptVisitorTrait
      * @param            $nodeOrNodes
      * @param string|int $key
      * @return array|NodeInterface|NodeInterface[]|null
-     * @throws VisitorBreak
      */
     protected function visitNodeOrNodes($nodeOrNodes, $key)
     {
@@ -121,7 +119,6 @@ trait AcceptVisitorTrait
      * @param NodeInterface[] $nodes
      * @param string|int      $key
      * @return NodeInterface[]
-     * @throws VisitorBreak
      */
     protected function visitNodes(array $nodes, $key): array
     {
@@ -149,7 +146,6 @@ trait AcceptVisitorTrait
      * @param string|int                       $key
      * @param NodeInterface|null               $parent
      * @return NodeInterface|null
-     * @throws VisitorBreak
      */
     protected function visitNode(NodeInterface $node, $key, ?NodeInterface $parent): ?NodeInterface
     {

--- a/src/Language/AST/Visitor/ParallelVisitor.php
+++ b/src/Language/AST/Visitor/ParallelVisitor.php
@@ -32,7 +32,6 @@ class ParallelVisitor implements VisitorInterface
      * @param NodeInterface|null               $parent
      * @param array                            $path
      * @return NodeInterface|SerializationInterface|null
-     * @throws VisitorBreak
      */
     public function enterNode(
         NodeInterface $node,
@@ -68,7 +67,6 @@ class ParallelVisitor implements VisitorInterface
      * @param NodeInterface|null               $parent
      * @param array                            $path
      * @return NodeInterface|SerializationInterface|null
-     * @throws VisitorBreak
      */
     public function leaveNode(
         NodeInterface $node,

--- a/src/Language/AST/Visitor/TypeInfoVisitor.php
+++ b/src/Language/AST/Visitor/TypeInfoVisitor.php
@@ -51,7 +51,6 @@ class TypeInfoVisitor extends Visitor
     /**
      * @inheritdoc
      * @throws \Exception
-     * @throws \TypeError
      */
     public function enterNode(
         NodeInterface $node,

--- a/src/Language/AST/Visitor/TypeInfoVisitor.php
+++ b/src/Language/AST/Visitor/TypeInfoVisitor.php
@@ -50,7 +50,6 @@ class TypeInfoVisitor extends Visitor
 
     /**
      * @inheritdoc
-     * @throws \Exception
      */
     public function enterNode(
         NodeInterface $node,

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Language;
 
+use Digia\GraphQL\Error\LanguageException;
 use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\Reader\ReaderInterface;
 
@@ -109,7 +110,6 @@ class Lexer implements LexerInterface
 
     /**
      * @inheritdoc
-     * @throws \Exception
      */
     public function getBody(): string
     {
@@ -142,7 +142,6 @@ class Lexer implements LexerInterface
 
     /**
      * @inheritdoc
-     * @throws \Exception
      */
     public function getSource(): Source
     {
@@ -150,7 +149,7 @@ class Lexer implements LexerInterface
             return $this->source;
         }
 
-        throw new \Exception('No source has been set.');
+        throw new LanguageException('No source has been set.');
     }
 
     /**

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -2,8 +2,7 @@
 
 namespace Digia\GraphQL\Language;
 
-use Digia\GraphQL\Error\GraphQLError;
-use Digia\GraphQL\Error\SyntaxError;
+use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\Reader\ReaderInterface;
 
 class Lexer implements LexerInterface
@@ -187,7 +186,7 @@ class Lexer implements LexerInterface
      * @param int   $col
      * @param Token $prev
      * @return Token
-     * @throws SyntaxError
+     * @throws SyntaxErrorException
      */
     public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
     {
@@ -195,13 +194,13 @@ class Lexer implements LexerInterface
             return $reader->read($code, $pos, $line, $col, $prev);
         }
 
-        throw new SyntaxError($this->unexpectedCharacterMessage($code));
+        throw new SyntaxErrorException($this->unexpectedCharacterMessage($code));
     }
 
     /**
      * @param Token $prev
      * @return Token
-     * @throws GraphQLError
+     * @throws SyntaxErrorException
      */
     protected function readToken(Token $prev): Token
     {
@@ -219,7 +218,7 @@ class Lexer implements LexerInterface
         $code = charCodeAt($body, $pos);
 
         if (isSourceCharacter($code)) {
-            throw new SyntaxError(sprintf('Cannot contain the invalid character %s', printCharCode($code)));
+            throw new SyntaxErrorException(sprintf('Cannot contain the invalid character %s', printCharCode($code)));
         }
 
         return $this->read($code, $pos, $line, $col, $prev);

--- a/src/Language/LexerInterface.php
+++ b/src/Language/LexerInterface.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Language;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\SyntaxErrorException;
 
 interface LexerInterface
 {
@@ -11,7 +11,7 @@ interface LexerInterface
      * Advances the token stream to the next non-ignored token.
      *
      * @return Token
-     * @throws GraphQLError
+     * @throws SyntaxErrorException
      */
     public function advance(): Token;
 
@@ -20,7 +20,7 @@ interface LexerInterface
      * the Lexer's state.
      *
      * @return Token
-     * @throws GraphQLError
+     * @throws SyntaxErrorException
      */
     public function lookahead(): Token;
 

--- a/src/Language/LexerInterface.php
+++ b/src/Language/LexerInterface.php
@@ -2,8 +2,6 @@
 
 namespace Digia\GraphQL\Language;
 
-use Digia\GraphQL\Error\SyntaxErrorException;
-
 interface LexerInterface
 {
 
@@ -11,7 +9,6 @@ interface LexerInterface
      * Advances the token stream to the next non-ignored token.
      *
      * @return Token
-     * @throws SyntaxErrorException
      */
     public function advance(): Token;
 
@@ -20,7 +17,6 @@ interface LexerInterface
      * the Lexer's state.
      *
      * @return Token
-     * @throws SyntaxErrorException
      */
     public function lookahead(): Token;
 

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -2,7 +2,6 @@
 
 namespace Digia\GraphQL\Language;
 
-use Digia\GraphQL\Error\LanguageException;
 use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\AST\Builder\DirectorInterface;
 use Digia\GraphQL\Language\AST\Builder\NodeBuilderInterface;
@@ -31,7 +30,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @inheritdoc
      * @return NodeInterface
-     * @throws \ReflectionException
      */
     public function parse(LexerInterface $lexer): NodeInterface
     {
@@ -41,7 +39,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @inheritdoc
      * @return NodeInterface
-     * @throws LanguageException
      */
     public function parseValue(LexerInterface $lexer): NodeInterface
     {
@@ -51,7 +48,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @inheritdoc
      * @return NodeInterface
-     * @throws LanguageException
      */
     public function parseType(LexerInterface $lexer): NodeInterface
     {
@@ -61,7 +57,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      * @throws \ReflectionException
      */
     protected function parseAST(LexerInterface $lexer): array
@@ -72,7 +68,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseValueAST(LexerInterface $lexer): array
     {
@@ -86,7 +82,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseTypeAST(LexerInterface $lexer): array
     {
@@ -125,7 +121,6 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param string         $kind
      * @return bool
-     * @throws LanguageException
      */
     protected function skip(LexerInterface $lexer, string $kind): bool
     {
@@ -143,7 +138,6 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param string         $kind
      * @return Token
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function expect(LexerInterface $lexer, string $kind): Token
@@ -162,7 +156,6 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param string         $value
      * @return Token
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function expectKeyword(LexerInterface $lexer, string $value): Token
@@ -216,7 +209,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param callable       $parseFunction
      * @param string         $closeKind
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function any(LexerInterface $lexer, string $openKind, callable $parseFunction, string $closeKind): array
     {
@@ -242,7 +235,6 @@ class Parser implements ParserInterface, DirectorInterface
      * @param callable       $parseFunction
      * @param string         $closeKind
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function many(LexerInterface $lexer, string $openKind, callable $parseFunction, string $closeKind): array
@@ -261,7 +253,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseName(LexerInterface $lexer): array
@@ -278,7 +269,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      * @throws \ReflectionException
      */
     protected function parseDocument(LexerInterface $lexer): array
@@ -303,9 +294,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
-     * @throws \ReflectionException
      * @throws SyntaxErrorException
+     * @throws \ReflectionException
      */
     protected function parseDefinition(LexerInterface $lexer): array
     {
@@ -343,7 +333,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseExecutableDefinition(LexerInterface $lexer): array
@@ -367,7 +356,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseOperationDefinition(LexerInterface $lexer): array
@@ -406,7 +394,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return string
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseOperationType(LexerInterface $lexer): string
@@ -424,7 +411,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseVariableDefinitions(LexerInterface $lexer): array
@@ -437,7 +423,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseVariableDefinition(LexerInterface $lexer): array
@@ -447,7 +432,6 @@ class Parser implements ParserInterface, DirectorInterface
         /**
          * @param LexerInterface $lexer
          * @return mixed
-         * @throws LanguageException
          * @throws SyntaxErrorException
          */
         $parseType = function (LexerInterface $lexer) {
@@ -469,7 +453,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseVariable(LexerInterface $lexer): array
@@ -488,7 +471,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      * @throws SyntaxErrorException
      */
     protected function parseSelectionSet(LexerInterface $lexer): array
@@ -510,7 +492,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseSelection(LexerInterface $lexer): array
     {
@@ -522,7 +504,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseField(LexerInterface $lexer): array
     {
@@ -554,7 +536,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseArguments(LexerInterface $lexer, bool $isConst): array
     {
@@ -571,7 +553,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseArgument(LexerInterface $lexer): array
     {
@@ -580,7 +562,7 @@ class Parser implements ParserInterface, DirectorInterface
         /**
          * @param LexerInterface $lexer
          * @return mixed
-         * @throws LanguageException
+         * @throws SyntaxErrorException
          */
         $parseValue = function (LexerInterface $lexer) {
             $this->expect($lexer, TokenKindEnum::COLON);
@@ -598,7 +580,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseConstArgument(LexerInterface $lexer): array
     {
@@ -607,7 +589,7 @@ class Parser implements ParserInterface, DirectorInterface
         /**
          * @param LexerInterface $lexer
          * @return mixed
-         * @throws LanguageException
+         * @throws SyntaxErrorException
          */
         $parseValue = function (LexerInterface $lexer) {
             $this->expect($lexer, TokenKindEnum::COLON);
@@ -625,7 +607,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseFragment(LexerInterface $lexer): array
     {
@@ -662,7 +644,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseFragmentDefinition(LexerInterface $lexer): array
     {
@@ -689,7 +671,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseFragmentName(LexerInterface $lexer): array
     {
@@ -704,7 +686,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseValueLiteral(LexerInterface $lexer, bool $isConst): array
     {
@@ -774,7 +756,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
      */
     protected function parseStringLiteral(LexerInterface $lexer): array
     {
@@ -793,7 +774,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseConstValue(LexerInterface $lexer): array
     {
@@ -803,7 +784,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseValueValue(LexerInterface $lexer): array
     {
@@ -814,7 +795,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseList(LexerInterface $lexer, bool $isConst): array
     {
@@ -836,7 +817,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseObject(LexerInterface $lexer, bool $isConst): array
     {
@@ -861,7 +842,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseObjectField(LexerInterface $lexer, bool $isConst): array
     {
@@ -884,7 +865,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseDirectives(LexerInterface $lexer, bool $isConst): array
     {
@@ -901,7 +882,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseDirective(LexerInterface $lexer, bool $isConst): array
     {
@@ -920,7 +901,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseTypeReference(LexerInterface $lexer): array
     {
@@ -954,7 +935,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseNamedType(LexerInterface $lexer): array
     {
@@ -970,7 +951,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      * @throws \ReflectionException
      */
     protected function parseTypeSystemDefinition(LexerInterface $lexer): array
@@ -1016,7 +997,6 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array|null
-     * @throws LanguageException
      */
     protected function parseDescription(LexerInterface $lexer): ?array
     {
@@ -1026,7 +1006,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseSchemaDefinition(LexerInterface $lexer): array
     {
@@ -1054,7 +1034,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseOperationTypeDefinition(LexerInterface $lexer): array
     {
@@ -1077,7 +1057,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseScalarTypeDefinition(LexerInterface $lexer): array
     {
@@ -1102,7 +1082,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseObjectTypeDefinition(LexerInterface $lexer): array
     {
@@ -1131,7 +1111,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseImplementsInterfaces(LexerInterface $lexer): array
     {
@@ -1154,7 +1134,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseFieldsDefinition(LexerInterface $lexer): array
     {
@@ -1166,7 +1146,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseFieldDefinition(LexerInterface $lexer): array
     {
@@ -1195,7 +1175,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseArgumentsDefinition(LexerInterface $lexer): array
     {
@@ -1207,7 +1187,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseInputValueDefinition(LexerInterface $lexer): array
     {
@@ -1236,7 +1216,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseInterfaceTypeDefinition(LexerInterface $lexer): array
     {
@@ -1263,7 +1243,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseUnionTypeDefinition(LexerInterface $lexer): array
     {
@@ -1290,7 +1270,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseUnionMemberTypes(LexerInterface $lexer): array
     {
@@ -1311,7 +1291,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseEnumTypeDefinition(LexerInterface $lexer): array
     {
@@ -1338,7 +1318,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseEnumValuesDefinition(LexerInterface $lexer): array
     {
@@ -1350,7 +1330,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseEnumValueDefinition(LexerInterface $lexer): array
     {
@@ -1372,7 +1352,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseInputObjectTypeDefinition(LexerInterface $lexer): array
     {
@@ -1399,7 +1379,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseInputFieldsDefinition(LexerInterface $lexer): array
     {
@@ -1411,7 +1391,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseTypeExtension(LexerInterface $lexer): array
     {
@@ -1440,7 +1420,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseScalarTypeExtension(LexerInterface $lexer): array
     {
@@ -1467,7 +1447,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseObjectTypeExtension(LexerInterface $lexer): array
     {
@@ -1498,7 +1478,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseInterfaceTypeExtension(LexerInterface $lexer): array
     {
@@ -1527,7 +1507,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseUnionTypeExtension(LexerInterface $lexer): array
     {
@@ -1556,7 +1536,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseEnumTypeExtension(LexerInterface $lexer): array
     {
@@ -1585,7 +1565,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseInputObjectTypeExtension(LexerInterface $lexer): array
     {
@@ -1614,7 +1594,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      * @throws \ReflectionException
      */
     protected function parseDirectiveDefinition(LexerInterface $lexer): array
@@ -1646,7 +1626,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      * @throws \ReflectionException
      */
     protected function parseDirectiveLocations(LexerInterface $lexer): array
@@ -1665,7 +1645,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws LanguageException
+     * @throws SyntaxErrorException
      * @throws \ReflectionException
      */
     protected function parseDirectiveLocation(LexerInterface $lexer): array

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -2,8 +2,8 @@
 
 namespace Digia\GraphQL\Language;
 
-use Digia\GraphQL\Error\GraphQLError;
-use Digia\GraphQL\Error\SyntaxError;
+use Digia\GraphQL\Error\LanguageException;
+use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\AST\Builder\DirectorInterface;
 use Digia\GraphQL\Language\AST\Builder\NodeBuilderInterface;
 use Digia\GraphQL\Language\AST\DirectiveLocationEnum;
@@ -32,7 +32,6 @@ class Parser implements ParserInterface, DirectorInterface
      * @inheritdoc
      * @return NodeInterface
      * @throws \ReflectionException
-     * @throws GraphQLError
      */
     public function parse(LexerInterface $lexer): NodeInterface
     {
@@ -42,7 +41,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @inheritdoc
      * @return NodeInterface
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     public function parseValue(LexerInterface $lexer): NodeInterface
     {
@@ -52,7 +51,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @inheritdoc
      * @return NodeInterface
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     public function parseType(LexerInterface $lexer): NodeInterface
     {
@@ -62,7 +61,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      * @throws \ReflectionException
      */
     protected function parseAST(LexerInterface $lexer): array
@@ -73,7 +72,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseValueAST(LexerInterface $lexer): array
     {
@@ -87,7 +86,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseTypeAST(LexerInterface $lexer): array
     {
@@ -126,7 +125,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param string         $kind
      * @return bool
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function skip(LexerInterface $lexer, string $kind): bool
     {
@@ -144,7 +143,8 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param string         $kind
      * @return Token
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function expect(LexerInterface $lexer, string $kind): Token
     {
@@ -155,14 +155,15 @@ class Parser implements ParserInterface, DirectorInterface
             return $token;
         }
 
-        throw new SyntaxError(sprintf('Expected %s, found %s', $kind, $token));
+        throw new SyntaxErrorException(sprintf('Expected %s, found %s', $kind, $token));
     }
 
     /**
      * @param LexerInterface $lexer
      * @param string         $value
      * @return Token
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function expectKeyword(LexerInterface $lexer, string $value): Token
     {
@@ -173,7 +174,7 @@ class Parser implements ParserInterface, DirectorInterface
             return $token;
         }
 
-        throw new SyntaxError(sprintf('Expected %s, found %s', $value, $token));
+        throw new SyntaxErrorException(sprintf('Expected %s, found %s', $value, $token));
     }
 
     /**
@@ -182,13 +183,13 @@ class Parser implements ParserInterface, DirectorInterface
      *
      * @param LexerInterface $lexer
      * @param Token|null     $atToken
-     * @return GraphQLError
+     * @return SyntaxErrorException
      */
-    protected function unexpected(LexerInterface $lexer, ?Token $atToken = null): GraphQLError
+    protected function unexpected(LexerInterface $lexer, ?Token $atToken = null): SyntaxErrorException
     {
         $token = $atToken ?: $lexer->getToken();
 
-        return new SyntaxError(sprintf('Unexpected %s', $token));
+        return new SyntaxErrorException(sprintf('Unexpected %s', $token));
     }
 
     /**
@@ -215,7 +216,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param callable       $parseFunction
      * @param string         $closeKind
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function any(LexerInterface $lexer, string $openKind, callable $parseFunction, string $closeKind): array
     {
@@ -241,7 +242,8 @@ class Parser implements ParserInterface, DirectorInterface
      * @param callable       $parseFunction
      * @param string         $closeKind
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function many(LexerInterface $lexer, string $openKind, callable $parseFunction, string $closeKind): array
     {
@@ -259,7 +261,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseName(LexerInterface $lexer): array
     {
@@ -275,7 +278,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      * @throws \ReflectionException
      */
     protected function parseDocument(LexerInterface $lexer): array
@@ -300,8 +303,9 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      * @throws \ReflectionException
+     * @throws SyntaxErrorException
      */
     protected function parseDefinition(LexerInterface $lexer): array
     {
@@ -339,7 +343,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseExecutableDefinition(LexerInterface $lexer): array
     {
@@ -362,7 +367,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseOperationDefinition(LexerInterface $lexer): array
     {
@@ -400,7 +406,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return string
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseOperationType(LexerInterface $lexer): string
     {
@@ -417,7 +424,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseVariableDefinitions(LexerInterface $lexer): array
     {
@@ -429,7 +437,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseVariableDefinition(LexerInterface $lexer): array
     {
@@ -438,7 +447,8 @@ class Parser implements ParserInterface, DirectorInterface
         /**
          * @param LexerInterface $lexer
          * @return mixed
-         * @throws GraphQLError
+         * @throws LanguageException
+         * @throws SyntaxErrorException
          */
         $parseType = function (LexerInterface $lexer) {
             $this->expect($lexer, TokenKindEnum::COLON);
@@ -459,7 +469,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseVariable(LexerInterface $lexer): array
     {
@@ -477,7 +488,8 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
+     * @throws SyntaxErrorException
      */
     protected function parseSelectionSet(LexerInterface $lexer): array
     {
@@ -498,7 +510,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseSelection(LexerInterface $lexer): array
     {
@@ -510,7 +522,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseField(LexerInterface $lexer): array
     {
@@ -542,7 +554,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseArguments(LexerInterface $lexer, bool $isConst): array
     {
@@ -559,7 +571,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseArgument(LexerInterface $lexer): array
     {
@@ -568,7 +580,7 @@ class Parser implements ParserInterface, DirectorInterface
         /**
          * @param LexerInterface $lexer
          * @return mixed
-         * @throws GraphQLError
+         * @throws LanguageException
          */
         $parseValue = function (LexerInterface $lexer) {
             $this->expect($lexer, TokenKindEnum::COLON);
@@ -586,7 +598,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseConstArgument(LexerInterface $lexer): array
     {
@@ -595,7 +607,7 @@ class Parser implements ParserInterface, DirectorInterface
         /**
          * @param LexerInterface $lexer
          * @return mixed
-         * @throws GraphQLError
+         * @throws LanguageException
          */
         $parseValue = function (LexerInterface $lexer) {
             $this->expect($lexer, TokenKindEnum::COLON);
@@ -613,7 +625,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseFragment(LexerInterface $lexer): array
     {
@@ -650,7 +662,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseFragmentDefinition(LexerInterface $lexer): array
     {
@@ -677,7 +689,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseFragmentName(LexerInterface $lexer): array
     {
@@ -692,7 +704,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseValueLiteral(LexerInterface $lexer, bool $isConst): array
     {
@@ -762,7 +774,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseStringLiteral(LexerInterface $lexer): array
     {
@@ -781,7 +793,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseConstValue(LexerInterface $lexer): array
     {
@@ -791,7 +803,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseValueValue(LexerInterface $lexer): array
     {
@@ -802,7 +814,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseList(LexerInterface $lexer, bool $isConst): array
     {
@@ -824,7 +836,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseObject(LexerInterface $lexer, bool $isConst): array
     {
@@ -849,7 +861,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseObjectField(LexerInterface $lexer, bool $isConst): array
     {
@@ -872,7 +884,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseDirectives(LexerInterface $lexer, bool $isConst): array
     {
@@ -889,7 +901,7 @@ class Parser implements ParserInterface, DirectorInterface
      * @param LexerInterface $lexer
      * @param bool           $isConst
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseDirective(LexerInterface $lexer, bool $isConst): array
     {
@@ -908,7 +920,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseTypeReference(LexerInterface $lexer): array
     {
@@ -942,7 +954,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseNamedType(LexerInterface $lexer): array
     {
@@ -958,7 +970,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      * @throws \ReflectionException
      */
     protected function parseTypeSystemDefinition(LexerInterface $lexer): array
@@ -1004,7 +1016,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array|null
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseDescription(LexerInterface $lexer): ?array
     {
@@ -1014,7 +1026,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseSchemaDefinition(LexerInterface $lexer): array
     {
@@ -1042,7 +1054,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseOperationTypeDefinition(LexerInterface $lexer): array
     {
@@ -1065,7 +1077,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseScalarTypeDefinition(LexerInterface $lexer): array
     {
@@ -1090,7 +1102,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseObjectTypeDefinition(LexerInterface $lexer): array
     {
@@ -1119,7 +1131,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseImplementsInterfaces(LexerInterface $lexer): array
     {
@@ -1142,7 +1154,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseFieldsDefinition(LexerInterface $lexer): array
     {
@@ -1154,7 +1166,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseFieldDefinition(LexerInterface $lexer): array
     {
@@ -1183,7 +1195,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseArgumentsDefinition(LexerInterface $lexer): array
     {
@@ -1195,7 +1207,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseInputValueDefinition(LexerInterface $lexer): array
     {
@@ -1224,7 +1236,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseInterfaceTypeDefinition(LexerInterface $lexer): array
     {
@@ -1251,7 +1263,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseUnionTypeDefinition(LexerInterface $lexer): array
     {
@@ -1278,7 +1290,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseUnionMemberTypes(LexerInterface $lexer): array
     {
@@ -1299,7 +1311,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseEnumTypeDefinition(LexerInterface $lexer): array
     {
@@ -1326,7 +1338,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseEnumValuesDefinition(LexerInterface $lexer): array
     {
@@ -1338,7 +1350,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseEnumValueDefinition(LexerInterface $lexer): array
     {
@@ -1360,7 +1372,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseInputObjectTypeDefinition(LexerInterface $lexer): array
     {
@@ -1387,7 +1399,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseInputFieldsDefinition(LexerInterface $lexer): array
     {
@@ -1399,7 +1411,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseTypeExtension(LexerInterface $lexer): array
     {
@@ -1428,7 +1440,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseScalarTypeExtension(LexerInterface $lexer): array
     {
@@ -1455,7 +1467,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseObjectTypeExtension(LexerInterface $lexer): array
     {
@@ -1486,7 +1498,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseInterfaceTypeExtension(LexerInterface $lexer): array
     {
@@ -1515,7 +1527,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseUnionTypeExtension(LexerInterface $lexer): array
     {
@@ -1544,7 +1556,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseEnumTypeExtension(LexerInterface $lexer): array
     {
@@ -1573,7 +1585,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      */
     protected function parseInputObjectTypeExtension(LexerInterface $lexer): array
     {
@@ -1602,7 +1614,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      * @throws \ReflectionException
      */
     protected function parseDirectiveDefinition(LexerInterface $lexer): array
@@ -1634,7 +1646,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      * @throws \ReflectionException
      */
     protected function parseDirectiveLocations(LexerInterface $lexer): array
@@ -1653,7 +1665,7 @@ class Parser implements ParserInterface, DirectorInterface
     /**
      * @param LexerInterface $lexer
      * @return array
-     * @throws GraphQLError
+     * @throws LanguageException
      * @throws \ReflectionException
      */
     protected function parseDirectiveLocation(LexerInterface $lexer): array

--- a/src/Language/ParserInterface.php
+++ b/src/Language/ParserInterface.php
@@ -9,7 +9,6 @@ interface ParserInterface
 
     /**
      * Given a GraphQL source, parses it into a Document.
-     * Throws GraphQLError if a syntax error is encountered.
      *
      * @param LexerInterface $lexer
      * @return NodeInterface
@@ -19,7 +18,7 @@ interface ParserInterface
     /**
      * Given a string containing a GraphQL value (ex. `[42]`), parse the AST for
      * that value.
-     * Throws GraphQLError if a syntax error is encountered.
+     * 
      * This is useful within tools that operate upon GraphQL Values directly and
      * in isolation of complete GraphQL documents.
      *
@@ -31,7 +30,7 @@ interface ParserInterface
     /**
      * Given a string containing a GraphQL Type (ex. `[Int!]`), parse the AST for
      * that type.
-     * Throws GraphQLError if a syntax error is encountered.
+     * 
      * This is useful within tools that operate upon GraphQL Types directly and
      * in isolation of complete GraphQL documents.
      *

--- a/src/Language/Reader/BlockStringReader.php
+++ b/src/Language/Reader/BlockStringReader.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Language\Reader;
 
-use Digia\GraphQL\Error\SyntaxError;
+use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\Token;
 use Digia\GraphQL\Language\TokenKindEnum;
 use function Digia\GraphQL\Language\blockStringValue;
@@ -23,7 +23,7 @@ class BlockStringReader extends AbstractReader
 
     /**
      * @inheritdoc
-     * @throws SyntaxError
+     * @throws SyntaxErrorException
      */
     public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
     {
@@ -51,7 +51,7 @@ class BlockStringReader extends AbstractReader
             }
 
             if (isSourceCharacter($code)) {
-                throw new SyntaxError(sprintf('Invalid character within String: %s', printCharCode($code)));
+                throw new SyntaxErrorException(sprintf('Invalid character within String: %s', printCharCode($code)));
             }
 
             if ($this->isEscapedTripleQuote($body, $code, $pos)) {
@@ -63,7 +63,7 @@ class BlockStringReader extends AbstractReader
             }
         }
 
-        throw new SyntaxError('Unterminated string.');
+        throw new SyntaxErrorException('Unterminated string.');
     }
 
     /**

--- a/src/Language/Reader/BlockStringReader.php
+++ b/src/Language/Reader/BlockStringReader.php
@@ -23,7 +23,6 @@ class BlockStringReader extends AbstractReader
 
     /**
      * @inheritdoc
-     * @throws SyntaxErrorException
      */
     public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
     {

--- a/src/Language/Reader/NumberReader.php
+++ b/src/Language/Reader/NumberReader.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Language\Reader;
 
-use Digia\GraphQL\Error\SyntaxError;
+use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\Token;
 use Digia\GraphQL\Language\TokenKindEnum;
 use function Digia\GraphQL\Language\charCodeAt;
@@ -24,7 +24,7 @@ class NumberReader extends AbstractReader
 
     /**
      * @inheritdoc
-     * @throws SyntaxError
+     * @throws SyntaxErrorException
      */
     public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
     {
@@ -41,7 +41,7 @@ class NumberReader extends AbstractReader
             // 0
             $code = charCodeAt($body, ++$pos);
             if (isNumber($code)) {
-                throw new SyntaxError(sprintf('Invalid number, unexpected digit after 0: %s.', printCharCode($code)));
+                throw new SyntaxErrorException(sprintf('Invalid number, unexpected digit after 0: %s.', printCharCode($code)));
             }
         } else {
             $pos  = $this->readDigits($code, $pos);
@@ -92,7 +92,7 @@ class NumberReader extends AbstractReader
      * @param int $pos
      * @param int $code
      * @return int
-     * @throws SyntaxError
+     * @throws SyntaxErrorException
      */
     protected function readDigits(int $code, int $pos): int
     {
@@ -106,6 +106,6 @@ class NumberReader extends AbstractReader
             return $pos;
         }
 
-        throw new SyntaxError(sprintf('Invalid number, expected digit but got: %s', printCharCode($code)));
+        throw new SyntaxErrorException(sprintf('Invalid number, expected digit but got: %s', printCharCode($code)));
     }
 }

--- a/src/Language/Reader/NumberReader.php
+++ b/src/Language/Reader/NumberReader.php
@@ -24,7 +24,6 @@ class NumberReader extends AbstractReader
 
     /**
      * @inheritdoc
-     * @throws SyntaxErrorException
      */
     public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
     {
@@ -41,7 +40,8 @@ class NumberReader extends AbstractReader
             // 0
             $code = charCodeAt($body, ++$pos);
             if (isNumber($code)) {
-                throw new SyntaxErrorException(sprintf('Invalid number, unexpected digit after 0: %s.', printCharCode($code)));
+                throw new SyntaxErrorException(sprintf('Invalid number, unexpected digit after 0: %s.',
+                    printCharCode($code)));
             }
         } else {
             $pos  = $this->readDigits($code, $pos);
@@ -89,8 +89,8 @@ class NumberReader extends AbstractReader
     }
 
     /**
-     * @param int $pos
      * @param int $code
+     * @param int $pos
      * @return int
      * @throws SyntaxErrorException
      */

--- a/src/Language/Reader/StringReader.php
+++ b/src/Language/Reader/StringReader.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Language\Reader;
 
-use Digia\GraphQL\Error\SyntaxError;
+use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\Token;
 use Digia\GraphQL\Language\TokenKindEnum;
 use function Digia\GraphQL\Language\charCodeAt;
@@ -22,7 +22,7 @@ class StringReader extends AbstractReader
 
     /**
      * @inheritdoc
-     * @throws SyntaxError
+     * @throws SyntaxErrorException
      */
     public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
     {
@@ -42,7 +42,7 @@ class StringReader extends AbstractReader
             }
 
             if ($this->isSourceCharacter($code)) {
-                throw new SyntaxError(sprintf('Invalid character within String: %s', printCharCode($code)));
+                throw new SyntaxErrorException(sprintf('Invalid character within String: %s', printCharCode($code)));
             }
 
             ++$pos;
@@ -86,7 +86,7 @@ class StringReader extends AbstractReader
                             charCodeAt($body, $pos + 4)
                         );
                         if ($charCode < 0) {
-                            throw new SyntaxError(
+                            throw new SyntaxErrorException(
                                 sprintf(
                                     'Invalid character escape sequence: \\u%s',
                                     sliceString($body, $pos + 1, $pos + 5)
@@ -97,7 +97,7 @@ class StringReader extends AbstractReader
                         $pos   += 4;
                         break;
                     default:
-                        throw new SyntaxError(sprintf('Invalid character escape sequence: \\%s', chr($code)));
+                        throw new SyntaxErrorException(sprintf('Invalid character escape sequence: \\%s', chr($code)));
                 }
 
                 ++$pos;
@@ -105,7 +105,7 @@ class StringReader extends AbstractReader
             }
         }
 
-        throw new SyntaxError('Unterminated string.');
+        throw new SyntaxErrorException('Unterminated string.');
     }
 
     /**

--- a/src/Language/Reader/StringReader.php
+++ b/src/Language/Reader/StringReader.php
@@ -22,7 +22,6 @@ class StringReader extends AbstractReader
 
     /**
      * @inheritdoc
-     * @throws SyntaxErrorException
      */
     public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
     {

--- a/src/Language/Source.php
+++ b/src/Language/Source.php
@@ -37,7 +37,7 @@ class Source
      * @param string              $body
      * @param null|string         $name
      * @param SourceLocation|null $locationOffset
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function __construct(string $body, ?string $name = 'GraphQL request', ?SourceLocation $locationOffset = null)
     {

--- a/src/Language/Source.php
+++ b/src/Language/Source.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Language;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\InvariantException;
 use function Digia\GraphQL\Util\invariant;
 
 /**
@@ -102,7 +102,7 @@ class Source
     /**
      * @param SourceLocation|null $locationOffset
      * @return Source
-     * @throws GraphQLError
+     * @throws InvariantException
      */
     protected function setLocationOffset(?SourceLocation $locationOffset): Source
     {

--- a/src/Provider/IntrospectionTypesProvider.php
+++ b/src/Provider/IntrospectionTypesProvider.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Provider;
 
+use Digia\GraphQL\Error\InvalidTypeException;
 use Digia\GraphQL\GraphQL;
 use Digia\GraphQL\Language\AST\DirectiveLocationEnum;
 use Digia\GraphQL\Type\Definition\AbstractType;
@@ -247,7 +248,7 @@ class IntrospectionTypesProvider extends AbstractServiceProvider
                                     return TypeKindEnum::NON_NULL;
                                 }
 
-                                throw new \Exception(sprintf('Unknown kind of type: %s', $type));
+                                throw new InvalidTypeException(sprintf('Unknown kind of type: %s', $type));
                             },
                         ],
                         'name'          => ['type' => GraphQLString()],

--- a/src/Provider/SchemaBuilderProvider.php
+++ b/src/Provider/SchemaBuilderProvider.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Provider;
 
+use Digia\GraphQL\Error\InvalidTypeException;
 use Digia\GraphQL\Language\AST\Node\NamedTypeNode;
 use Digia\GraphQL\Language\AST\Schema\DefinitionBuilder;
 use Digia\GraphQL\Language\AST\Schema\DefinitionBuilderInterface;
@@ -29,7 +30,7 @@ class SchemaBuilderProvider extends AbstractServiceProvider
         $this->container->add(DefinitionBuilderInterface::class, DefinitionBuilder::class, true/* $shared */)
             ->withArguments([
                 function (NamedTypeNode $node) {
-                    throw new \Exception(sprintf('Type "%s" not found in document.', $node->getNameValue()));
+                    throw new InvalidTypeException(sprintf('Type "%s" not found in document.', $node->getNameValue()));
                 },
                 CacheInterface::class,
             ]);

--- a/src/Type/Definition/ArgumentsTrait.php
+++ b/src/Type/Definition/ArgumentsTrait.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Type\Definition;
 
+use Digia\GraphQL\Error\InvariantException;
 use function Digia\GraphQL\Type\isAssocArray;
 use function Digia\GraphQL\Util\invariant;
 
@@ -32,7 +33,7 @@ trait ArgumentsTrait
     /**
      * @param Argument[] $arguments
      * @return $this
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function setArgs(array $arguments)
     {

--- a/src/Type/Definition/DeprecationTrait.php
+++ b/src/Type/Definition/DeprecationTrait.php
@@ -45,14 +45,4 @@ trait DeprecationTrait
 
         return $this;
     }
-
-    /**
-     * @param bool $isDeprecated
-     * @throws \TypeError
-     * @noinspection PhpUnusedParameterInspection
-     */
-    public function setIsDeprecated(bool $isDeprecated): void
-    {
-        throw new \TypeError('You should provide "deprecationReason" instead of "isDeprecated".');
-    }
 }

--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -3,6 +3,7 @@
 namespace Digia\GraphQL\Type\Definition;
 
 use Digia\GraphQL\Config\ConfigObject;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\EnumTypeDefinitionNode;
 use Digia\GraphQL\Language\AST\Node\NodeInterface;
 use Digia\GraphQL\Language\AST\Node\NodeTrait;
@@ -68,7 +69,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     /**
      * @param $value
      * @return null|string
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function serialize($value)
     {
@@ -85,7 +86,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     /**
      * @param $value
      * @return mixed|null
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function parseValue($value)
     {
@@ -104,7 +105,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     /**
      * @param NodeInterface $astNode
      * @return mixed|null
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function parseLiteral(NodeInterface $astNode)
     {
@@ -124,7 +125,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     /**
      * @param string $name
      * @return EnumValue
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function getValue(string $name): EnumValue
     {
@@ -133,7 +134,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
 
     /**
      * @return EnumValue[]
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function getValues(): array
     {
@@ -145,7 +146,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     /**
      * @param string $name
      * @return EnumValue|null
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function getValueByName(string $name): ?EnumValue
     {
@@ -161,7 +162,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     /**
      * @param mixed $value
      * @return EnumValue|null
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function getValueByValue($value): ?EnumValue
     {
@@ -186,7 +187,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     }
 
     /**
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineEnumValuesIfNecessary(): void
     {
@@ -200,7 +201,7 @@ class EnumType extends ConfigObject implements TypeInterface, NamedTypeInterface
     /**
      * @param array $valueMap
      * @return array
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineEnumValues(array $valueMap): array
     {

--- a/src/Type/Definition/FieldsTrait.php
+++ b/src/Type/Definition/FieldsTrait.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Type\Definition;
 
+use Digia\GraphQL\Error\InvariantException;
 use function Digia\GraphQL\Type\isAssocArray;
 use function Digia\GraphQL\Type\isValidResolver;
 use function Digia\GraphQL\Type\resolveThunk;
@@ -28,7 +29,6 @@ trait FieldsTrait
 
     /**
      * @return Field[]
-     * @throws \Exception
      */
     public function getFields(): array
     {
@@ -38,7 +38,7 @@ trait FieldsTrait
     }
 
     /**
-     * @throws \Exception
+     *
      */
     protected function defineFieldMapIfNecessary(): void
     {
@@ -64,7 +64,7 @@ trait FieldsTrait
     /**
      * @param mixed $fieldsThunk
      * @return array
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineFieldMap($fieldsThunk): array
     {

--- a/src/Type/Definition/InputObjectType.php
+++ b/src/Type/Definition/InputObjectType.php
@@ -19,6 +19,7 @@ namespace Digia\GraphQL\Type\Definition;
  */
 
 use Digia\GraphQL\Config\ConfigObject;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\InputObjectTypeDefinitionNode;
 use Digia\GraphQL\Language\AST\Node\NodeTrait;
 use function Digia\GraphQL\Type\isAssocArray;
@@ -55,7 +56,7 @@ class InputObjectType extends ConfigObject implements TypeInterface, NamedTypeIn
 
     /**
      * @return InputField[]
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function getFields(): array
     {
@@ -76,7 +77,7 @@ class InputObjectType extends ConfigObject implements TypeInterface, NamedTypeIn
     }
 
     /**
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function buildFieldMapIfNecessary()
     {
@@ -90,7 +91,7 @@ class InputObjectType extends ConfigObject implements TypeInterface, NamedTypeIn
     /**
      * @param array|callable $fieldsThunk
      * @return array
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineFieldMap($fieldsThunk): array
     {

--- a/src/Type/Definition/ListType.php
+++ b/src/Type/Definition/ListType.php
@@ -13,7 +13,6 @@ class ListType implements TypeInterface, WrappingTypeInterface
      * ListType constructor.
      *
      * @param TypeInterface $ofType
-     * @throws \TypeError
      */
     public function __construct(TypeInterface $ofType)
     {

--- a/src/Type/Definition/NonNullType.php
+++ b/src/Type/Definition/NonNullType.php
@@ -2,6 +2,8 @@
 
 namespace Digia\GraphQL\Type\Definition;
 
+use Digia\GraphQL\Error\InvalidTypeException;
+
 class NonNullType implements TypeInterface, WrappingTypeInterface
 {
 
@@ -13,7 +15,6 @@ class NonNullType implements TypeInterface, WrappingTypeInterface
      * NonNullType constructor.
      *
      * @param TypeInterface $ofType
-     * @throws \TypeError
      */
     public function __construct(TypeInterface $ofType)
     {
@@ -31,12 +32,12 @@ class NonNullType implements TypeInterface, WrappingTypeInterface
     /**
      * @param TypeInterface $ofType
      * @return $this
-     * @throws \TypeError
+     * @throws InvalidTypeException
      */
     public function setOfType(TypeInterface $ofType)
     {
         if ($ofType instanceof NonNullType) {
-            throw new \TypeError(sprintf('Expected %s to be a GraphQL nullable type.', $ofType));
+            throw new InvalidTypeException(sprintf('Expected %s to be a GraphQL nullable type.', $ofType));
         }
 
         $this->ofType = $ofType;

--- a/src/Type/Definition/NonNullType.php
+++ b/src/Type/Definition/NonNullType.php
@@ -15,6 +15,7 @@ class NonNullType implements TypeInterface, WrappingTypeInterface
      * NonNullType constructor.
      *
      * @param TypeInterface $ofType
+     * @throws InvalidTypeException
      */
     public function __construct(TypeInterface $ofType)
     {

--- a/src/Type/Definition/ObjectType.php
+++ b/src/Type/Definition/ObjectType.php
@@ -3,6 +3,7 @@
 namespace Digia\GraphQL\Type\Definition;
 
 use Digia\GraphQL\Config\ConfigObject;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\NodeTrait;
 use Digia\GraphQL\Language\AST\Node\ObjectTypeDefinitionNode;
 use function Digia\GraphQL\Type\resolveThunk;
@@ -77,7 +78,6 @@ class ObjectType extends ConfigObject implements TypeInterface, NamedTypeInterfa
 
     /**
      * @inheritdoc
-     * @throws \Exception
      */
     protected function afterConfig(): void
     {
@@ -109,7 +109,7 @@ class ObjectType extends ConfigObject implements TypeInterface, NamedTypeInterfa
 
     /**
      * @return InterfaceType[]
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function getInterfaces(): array
     {
@@ -149,7 +149,7 @@ class ObjectType extends ConfigObject implements TypeInterface, NamedTypeInterfa
     }
 
     /**
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineInterfacesIfNecessary()
     {
@@ -164,7 +164,7 @@ class ObjectType extends ConfigObject implements TypeInterface, NamedTypeInterfa
     /**
      * @param array|callable $interfacesThunk
      * @return array
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineInterfaces($interfacesThunk): array
     {

--- a/src/Type/Definition/OfTypeTrait.php
+++ b/src/Type/Definition/OfTypeTrait.php
@@ -21,7 +21,6 @@ trait OfTypeTrait
     /**
      * @param TypeInterface $ofType
      * @return $this
-     * @throws \TypeError
      */
     protected function setOfType(TypeInterface $ofType)
     {

--- a/src/Type/Definition/ScalarType.php
+++ b/src/Type/Definition/ScalarType.php
@@ -39,7 +39,6 @@ class ScalarType extends ConfigObject implements TypeInterface, NamedTypeInterfa
 
     /**
      * @inheritdoc
-     * @throws \Exception
      */
     protected function afterConfig(): void
     {
@@ -85,7 +84,8 @@ class ScalarType extends ConfigObject implements TypeInterface, NamedTypeInterfa
      */
     public function parseLiteral(...$args)
     {
-        return $this->_parseLiteralFunction !== null ? \call_user_func_array($this->_parseLiteralFunction, $args) : null;
+        return $this->_parseLiteralFunction !== null ? \call_user_func_array($this->_parseLiteralFunction,
+            $args) : null;
     }
 
     /**

--- a/src/Type/Definition/UnionType.php
+++ b/src/Type/Definition/UnionType.php
@@ -3,6 +3,7 @@
 namespace Digia\GraphQL\Type\Definition;
 
 use Digia\GraphQL\Config\ConfigObject;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\NodeTrait;
 use Digia\GraphQL\Language\AST\Node\UnionTypeDefinitionNode;
 use function Digia\GraphQL\Type\resolveThunk;
@@ -67,7 +68,7 @@ class UnionType extends ConfigObject implements AbstractTypeInterface, NamedType
 
     /**
      * @return TypeInterface[]
-     * @throws \Exception
+     * @throws InvariantException
      */
     public function getTypes(): array
     {
@@ -88,7 +89,7 @@ class UnionType extends ConfigObject implements AbstractTypeInterface, NamedType
     }
 
     /**
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineTypesIfNecessary()
     {
@@ -103,7 +104,7 @@ class UnionType extends ConfigObject implements AbstractTypeInterface, NamedType
     /**
      * @param array|callable $typesThunk
      * @return array
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function defineTypes($typesThunk): array
     {

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -3,6 +3,7 @@
 namespace Digia\GraphQL\Type;
 
 use Digia\GraphQL\Config\ConfigObject;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\NodeTrait;
 use Digia\GraphQL\Language\AST\Node\SchemaDefinitionNode;
 use Digia\GraphQL\Type\Definition\AbstractTypeInterface;
@@ -155,7 +156,6 @@ class Schema extends ConfigObject implements SchemaInterface
 
     /**
      * @inheritdoc
-     * @throws \Exception
      */
     public function isPossibleType(AbstractTypeInterface $abstractType, TypeInterface $possibleType): bool
     {
@@ -188,7 +188,6 @@ class Schema extends ConfigObject implements SchemaInterface
 
     /**
      * @inheritdoc
-     * @throws \Exception
      */
     public function getPossibleTypes(AbstractTypeInterface $abstractType): ?array
     {
@@ -216,7 +215,7 @@ class Schema extends ConfigObject implements SchemaInterface
     }
 
     /**
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function afterConfig(): void
     {
@@ -253,7 +252,7 @@ class Schema extends ConfigObject implements SchemaInterface
     }
 
     /**
-     * @throws \Exception
+     * @throws InvariantException
      */
     protected function buildImplementations()
     {
@@ -348,7 +347,7 @@ class Schema extends ConfigObject implements SchemaInterface
  * @param array              $map
  * @param null|TypeInterface $type
  * @return array
- * @throws \Exception
+ * @throws InvariantException
  */
 function typeMapReducer(array $map, ?TypeInterface $type): array
 {

--- a/src/Type/definition.php
+++ b/src/Type/definition.php
@@ -397,7 +397,6 @@ function GraphQLDirective(array $config = []): Directive
 /**
  * @param TypeInterface $ofType
  * @return ListType
- * @throws \TypeError
  */
 function GraphQLList(TypeInterface $ofType): ListType
 {
@@ -407,7 +406,6 @@ function GraphQLList(TypeInterface $ofType): ListType
 /**
  * @param TypeInterface $ofType
  * @return NonNullType
- * @throws \TypeError
  */
 function GraphQLNonNull(TypeInterface $ofType): NonNullType
 {

--- a/src/Type/definition.php
+++ b/src/Type/definition.php
@@ -2,6 +2,8 @@
 
 namespace Digia\GraphQL\Type;
 
+use Digia\GraphQL\Error\InvalidTypeException;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Type\Definition\AbstractTypeInterface;
 use Digia\GraphQL\Type\Definition\CompositeTypeInterface;
 use Digia\GraphQL\Type\Definition\Directive;
@@ -58,7 +60,7 @@ function isValidResolver($resolver): bool
 
 /**
  * @param $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertType($type)
 {
@@ -70,7 +72,7 @@ function assertType($type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertScalarType(TypeInterface $type)
 {
@@ -82,7 +84,7 @@ function assertScalarType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertObjectType(TypeInterface $type)
 {
@@ -94,7 +96,7 @@ function assertObjectType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertInterfaceType(TypeInterface $type)
 {
@@ -106,7 +108,7 @@ function assertInterfaceType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertUnionType(TypeInterface $type)
 {
@@ -118,7 +120,7 @@ function assertUnionType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertEnumType(TypeInterface $type)
 {
@@ -130,7 +132,7 @@ function assertEnumType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertInputObjectType(TypeInterface $type)
 {
@@ -142,7 +144,7 @@ function assertInputObjectType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertListType(TypeInterface $type)
 {
@@ -154,7 +156,7 @@ function assertListType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertNonNullType(TypeInterface $type)
 {
@@ -175,7 +177,7 @@ function isInputType(?TypeInterface $type): bool
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertInputType(TypeInterface $type)
 {
@@ -196,7 +198,7 @@ function isOutputType(?TypeInterface $type): bool
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertOutputType(TypeInterface $type)
 {
@@ -208,7 +210,7 @@ function assertOutputType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertLeafType(TypeInterface $type)
 {
@@ -220,7 +222,7 @@ function assertLeafType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertCompositeType(TypeInterface $type)
 {
@@ -232,7 +234,7 @@ function assertCompositeType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertAbstractType(TypeInterface $type)
 {
@@ -244,7 +246,7 @@ function assertAbstractType(TypeInterface $type)
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertWrappingType(TypeInterface $type)
 {
@@ -266,7 +268,7 @@ function isNullableType(TypeInterface $type): bool
 /**
  * @param TypeInterface $type
  * @return TypeInterface
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertNullableType(TypeInterface $type): TypeInterface
 {
@@ -293,7 +295,7 @@ function getNullableType(?TypeInterface $type): ?TypeInterface
 
 /**
  * @param TypeInterface $type
- * @throws \Exception
+ * @throws InvariantException
  */
 function assertNamedType(TypeInterface $type)
 {
@@ -406,6 +408,7 @@ function GraphQLList(TypeInterface $ofType): ListType
 /**
  * @param TypeInterface $ofType
  * @return NonNullType
+ * @throws InvalidTypeException
  */
 function GraphQLNonNull(TypeInterface $ofType): NonNullType
 {

--- a/src/Type/directives.php
+++ b/src/Type/directives.php
@@ -7,7 +7,6 @@ use function Digia\GraphQL\Util\arraySome;
 
 /**
  * @return Directive
- * @throws TypeError
  */
 function GraphQLIncludeDirective(): Directive
 {
@@ -16,7 +15,6 @@ function GraphQLIncludeDirective(): Directive
 
 /**
  * @return Directive
- * @throws TypeError
  */
 function GraphQLSkipDirective(): Directive
 {
@@ -27,7 +25,6 @@ const DEFAULT_DEPRECATION_REASON = 'No longer supported';
 
 /**
  * @return Directive
- * @throws TypeError
  */
 function GraphQLDeprecatedDirective(): Directive
 {
@@ -36,7 +33,6 @@ function GraphQLDeprecatedDirective(): Directive
 
 /**
  * @return array
- * @throws TypeError
  */
 function specifiedDirectives(): array
 {
@@ -50,7 +46,6 @@ function specifiedDirectives(): array
 /**
  * @param DirectiveInterface $directive
  * @return bool
- * @throws TypeError
  */
 function isSpecifiedDirective(DirectiveInterface $directive): bool
 {

--- a/src/Type/introspection.php
+++ b/src/Type/introspection.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Type;
 
+use Digia\GraphQL\Error\InvalidTypeException;
 use Digia\GraphQL\GraphQL;
 use Digia\GraphQL\Type\Definition\EnumType;
 use Digia\GraphQL\Type\Definition\Field;
@@ -75,6 +76,7 @@ function __TypeKind(): EnumType
 
 /**
  * @return Field
+ * @throws InvalidTypeException
  */
 function SchemaMetaFieldDefinition(): Field
 {
@@ -91,6 +93,7 @@ function SchemaMetaFieldDefinition(): Field
 
 /**
  * @return Field
+ * @throws InvalidTypeException
  */
 function TypeMetaFieldDefinition(): Field
 {
@@ -112,6 +115,7 @@ function TypeMetaFieldDefinition(): Field
 
 /**
  * @return Field
+ * @throws InvalidTypeException
  */
 function TypeNameMetaFieldDefinition(): Field
 {

--- a/src/Type/introspection.php
+++ b/src/Type/introspection.php
@@ -75,7 +75,6 @@ function __TypeKind(): EnumType
 
 /**
  * @return Field
- * @throws \TypeError
  */
 function SchemaMetaFieldDefinition(): Field
 {
@@ -92,7 +91,6 @@ function SchemaMetaFieldDefinition(): Field
 
 /**
  * @return Field
- * @throws \TypeError
  */
 function TypeMetaFieldDefinition(): Field
 {
@@ -114,7 +112,6 @@ function TypeMetaFieldDefinition(): Field
 
 /**
  * @return Field
- * @throws \TypeError
  */
 function TypeNameMetaFieldDefinition(): Field
 {

--- a/src/Util/TypeInfo.php
+++ b/src/Util/TypeInfo.php
@@ -282,7 +282,6 @@ class TypeInfo
  * @param TypeInterface   $parentType
  * @param FieldNode       $fieldNode
  * @return Field|null
- * @throws \TypeError
  * @throws \Exception
  */
 function getFieldDefinition(SchemaInterface $schema, TypeInterface $parentType, FieldNode $fieldNode): ?Field

--- a/src/Util/TypeInfo.php
+++ b/src/Util/TypeInfo.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Util;
 
+use Digia\GraphQL\Error\InvalidTypeException;
 use Digia\GraphQL\Language\AST\Node\FieldNode;
 use Digia\GraphQL\Type\Definition\Argument;
 use Digia\GraphQL\Type\Definition\CompositeTypeInterface;
@@ -282,7 +283,7 @@ class TypeInfo
  * @param TypeInterface   $parentType
  * @param FieldNode       $fieldNode
  * @return Field|null
- * @throws \Exception
+ * @throws InvalidTypeException
  */
 function getFieldDefinition(SchemaInterface $schema, TypeInterface $parentType, FieldNode $fieldNode): ?Field
 {

--- a/src/Util/coercers.php
+++ b/src/Util/coercers.php
@@ -2,18 +2,19 @@
 
 namespace Digia\GraphQL\Util;
 
+use Digia\GraphQL\Error\InvalidTypeException;
 use const Digia\GraphQL\Type\MAX_INT;
 use const Digia\GraphQL\Type\MIN_INT;
 
 /**
  * @param $value
  * @return bool
- * @throws \TypeError
+ * @throws InvalidTypeException
  */
 function coerceBoolean($value): bool
 {
     if (!is_scalar($value)) {
-        throw new \TypeError(sprintf('Boolean cannot represent a non-scalar value: %s', $value));
+        throw new InvalidTypeException(sprintf('Boolean cannot represent a non-scalar value: %s', $value));
     }
 
     return (bool)$value;
@@ -22,30 +23,30 @@ function coerceBoolean($value): bool
 /**
  * @param $value
  * @return float
- * @throws \TypeError
+ * @throws InvalidTypeException
  */
 function coerceFloat($value): float
 {
     if ($value === '') {
-        throw new \TypeError('Float cannot represent non numeric value: (empty string)');
+        throw new InvalidTypeException('Float cannot represent non numeric value: (empty string)');
     }
 
     if (is_numeric($value) || \is_bool($value)) {
         return (float)$value;
     }
 
-    throw new \TypeError(sprintf('Float cannot represent non numeric value: %s', $value));
+    throw new InvalidTypeException(sprintf('Float cannot represent non numeric value: %s', $value));
 }
 
 /**
  * @param $value
  * @return int
- * @throws \TypeError
+ * @throws InvalidTypeException
  */
 function coerceInt($value)
 {
     if ($value === '') {
-        throw new \TypeError('Int cannot represent non 32-bit signed integer value: (empty string)');
+        throw new InvalidTypeException('Int cannot represent non 32-bit signed integer value: (empty string)');
     }
 
     if (\is_bool($value)) {
@@ -53,14 +54,14 @@ function coerceInt($value)
     }
 
     if (!\is_int($value) || $value > MAX_INT || $value < MIN_INT) {
-        throw new \TypeError(sprintf('Int cannot represent non 32-bit signed integer value: %s', $value));
+        throw new InvalidTypeException(sprintf('Int cannot represent non 32-bit signed integer value: %s', $value));
     }
 
     $intValue   = (int)$value;
     $floatValue = (float)$value;
 
     if ($floatValue != $intValue || floor($floatValue) !== $floatValue) {
-        throw new \TypeError(sprintf('Int cannot represent non-integer value: %s', $value));
+        throw new InvalidTypeException(sprintf('Int cannot represent non-integer value: %s', $value));
     }
 
     return $intValue;
@@ -69,7 +70,7 @@ function coerceInt($value)
 /**
  * @param $value
  * @return string
- * @throws \TypeError
+ * @throws InvalidTypeException
  */
 function coerceString($value): string
 {
@@ -86,7 +87,7 @@ function coerceString($value): string
     }
 
     if (!is_scalar($value)) {
-        throw new \TypeError('String cannot represent a non-scalar value');
+        throw new InvalidTypeException('String cannot represent a non-scalar value');
     }
 
     return (string)$value;

--- a/src/Util/invariant.php
+++ b/src/Util/invariant.php
@@ -2,16 +2,16 @@
 
 namespace Digia\GraphQL\Util;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\InvariantException;
 
 /**
  * @param bool   $condition
  * @param string $message
- * @throws GraphQLError
+ * @throws InvariantException
  */
 function invariant(bool $condition, string $message)
 {
     if (!$condition) {
-        throw new GraphQLError($message);
+        throw new InvariantException($message);
     }
 }

--- a/src/Util/typeFromAST.php
+++ b/src/Util/typeFromAST.php
@@ -15,7 +15,6 @@ use function Digia\GraphQL\Type\GraphQLNonNull;
  * @param SchemaInterface   $schema
  * @param TypeNodeInterface $typeNode
  * @return TypeInterface|null
- * @throws \TypeError
  * @throws \Exception
  */
 function typeFromAST(SchemaInterface $schema, TypeNodeInterface $typeNode): ?TypeInterface

--- a/src/Util/typeFromAST.php
+++ b/src/Util/typeFromAST.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Util;
 
+use Digia\GraphQL\Error\InvalidTypeException;
 use Digia\GraphQL\Language\AST\Node\ListTypeNode;
 use Digia\GraphQL\Language\AST\Node\NamedTypeNode;
 use Digia\GraphQL\Language\AST\Node\NonNullTypeNode;
@@ -15,7 +16,7 @@ use function Digia\GraphQL\Type\GraphQLNonNull;
  * @param SchemaInterface   $schema
  * @param TypeNodeInterface $typeNode
  * @return TypeInterface|null
- * @throws \Exception
+ * @throws InvalidTypeException
  */
 function typeFromAST(SchemaInterface $schema, TypeNodeInterface $typeNode): ?TypeInterface
 {
@@ -35,5 +36,5 @@ function typeFromAST(SchemaInterface $schema, TypeNodeInterface $typeNode): ?Typ
         return $schema->getType($typeNode->getNameValue());
     }
 
-    throw new \Exception(sprintf('Unexpected type kind: %s', $typeNode->getKind()));
+    throw new InvalidTypeException(sprintf('Unexpected type kind: %s', $typeNode->getKind()));
 }

--- a/src/Util/valueFromAST.php
+++ b/src/Util/valueFromAST.php
@@ -2,6 +2,8 @@
 
 namespace Digia\GraphQL\Language;
 
+use Digia\GraphQL\Error\InvalidTypeException;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\EnumValueNode;
 use Digia\GraphQL\Language\AST\Node\FieldNode;
 use Digia\GraphQL\Language\AST\Node\ListValueNode;
@@ -24,7 +26,8 @@ use function Digia\GraphQL\Util\keyMap;
  * @param TypeInterface|InputTypeInterface $type
  * @param array                            $variables
  * @return mixed|null
- * @throws \Exception
+ * @throws InvalidTypeException
+ * @throws InvariantException
  */
 function valueFromAST(?ValueNodeInterface $node, TypeInterface $type, array $variables = [])
 {
@@ -162,7 +165,7 @@ function valueFromAST(?ValueNodeInterface $node, TypeInterface $type, array $var
         return $result;
     }
 
-    throw new \Exception(sprintf('Unknown type: %s', $type));
+    throw new InvalidTypeException(sprintf('Unknown type: %s', $type));
 }
 
 /**

--- a/src/facades.php
+++ b/src/facades.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL;
 
-use Digia\GraphQL\Error\ExecutionException;
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Execution\Execution;
 use Digia\GraphQL\Execution\ExecutionResult;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
@@ -19,7 +19,7 @@ use Digia\GraphQL\Util\SerializationInterface;
  * @param string|Source $source
  * @param array         $options
  * @return NodeInterface|DocumentNode|SerializationInterface
- * @throws \Exception
+ * @throws InvariantException
  */
 function parse($source, array $options = []): NodeInterface
 {
@@ -34,7 +34,7 @@ function parse($source, array $options = []): NodeInterface
  * @param string|Source $source
  * @param array         $options
  * @return NodeInterface|SerializationInterface
- * @throws \Exception
+ * @throws InvariantException
  */
 function parseValue($source, array $options = []): NodeInterface
 {
@@ -49,7 +49,7 @@ function parseValue($source, array $options = []): NodeInterface
  * @param string|Source $source
  * @param array         $options
  * @return NodeInterface|SerializationInterface
- * @throws \Exception
+ * @throws InvariantException
  */
 function parseType($source, array $options = []): NodeInterface
 {
@@ -64,8 +64,7 @@ function parseType($source, array $options = []): NodeInterface
  * @param string $source
  * @param array  $options
  * @return SchemaInterface
- * @throws \Digia\GraphQL\Error\ExecutionException
- * @throws \Exception
+ * @throws InvariantException
  */
 function buildSchema(string $source, array $options = []): SchemaInterface
 {
@@ -90,8 +89,7 @@ function printNode(NodeInterface $node): string
  * @param null            $operationName
  * @param callable|null   $fieldResolver
  * @return ExecutionResult
- * @throws Error\ExecutionException
- * @throws \Exception
+ * @throws InvariantException
  */
 function graphql(
     SchemaInterface $schema,

--- a/src/facades.php
+++ b/src/facades.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL;
 
-use Digia\GraphQL\Error\GraphQLError;
+use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Execution\Execution;
 use Digia\GraphQL\Execution\ExecutionResult;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
@@ -64,7 +64,7 @@ function parseType($source, array $options = []): NodeInterface
  * @param string $source
  * @param array  $options
  * @return SchemaInterface
- * @throws \Digia\GraphQL\Error\GraphQLError
+ * @throws \Digia\GraphQL\Error\ExecutionException
  * @throws \Exception
  */
 function buildSchema(string $source, array $options = []): SchemaInterface
@@ -90,7 +90,7 @@ function printNode(NodeInterface $node): string
  * @param null            $operationName
  * @param callable|null   $fieldResolver
  * @return ExecutionResult
- * @throws Error\GraphQLError
+ * @throws Error\ExecutionException
  * @throws \Exception
  */
 function graphql(

--- a/tests/Functional/Execution/ExecutionTest.php
+++ b/tests/Functional/Execution/ExecutionTest.php
@@ -95,9 +95,6 @@ class ExecutionTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExecuteHelloQuery()
     {
         $schema = new Schema([
@@ -166,9 +163,6 @@ class ExecutionTest extends TestCase
         $this->assertEquals($expected, $executionResult);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExecuteQueryHelloWithArgs()
     {
         $schema = GraphQLSchema([
@@ -257,9 +251,6 @@ class ExecutionTest extends TestCase
         $this->assertEquals($expected, $executionResult);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExecuteQueryWithMultipleFields()
     {
         $schema = new Schema([
@@ -402,10 +393,6 @@ class ExecutionTest extends TestCase
         $this->assertEquals($expected, $executionResult);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testHandleFragments()
     {
         $documentNode = parse('

--- a/tests/Functional/Execution/ExecutionTest.php
+++ b/tests/Functional/Execution/ExecutionTest.php
@@ -258,7 +258,6 @@ class ExecutionTest extends TestCase
     }
 
     /**
-     * @throws \TypeError
      * @throws \Exception
      */
     public function testExecuteQueryWithMultipleFields()

--- a/tests/Functional/Execution/ExecutionTest.php
+++ b/tests/Functional/Execution/ExecutionTest.php
@@ -403,7 +403,7 @@ class ExecutionTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testHandleFragments()

--- a/tests/Functional/Execution/MutationTest.php
+++ b/tests/Functional/Execution/MutationTest.php
@@ -68,7 +68,7 @@ class MutationTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testDoesNotIncludeIllegalFieldsInOutput()

--- a/tests/Functional/Execution/MutationTest.php
+++ b/tests/Functional/Execution/MutationTest.php
@@ -14,9 +14,6 @@ use function Digia\GraphQL\Type\GraphQLString;
 class MutationTest extends TestCase
 {
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleMutation()
     {
         $schema = GraphQLSchema([
@@ -67,10 +64,6 @@ class MutationTest extends TestCase
         $this->assertEquals($expected, $executionResult);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testDoesNotIncludeIllegalFieldsInOutput()
     {
         /** @var DocumentNode $documentNode */

--- a/tests/Functional/Language/ParserTest.php
+++ b/tests/Functional/Language/ParserTest.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Test\Functional\Language;
 
-use Digia\GraphQL\Error\SyntaxError;
+use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
 use Digia\GraphQL\Language\AST\Node\FieldNode;
 use Digia\GraphQL\Language\AST\Node\FragmentSpreadNode;
@@ -28,11 +28,11 @@ class ParserTest extends TestCase
      */
     public function testParseProvidesUsefulErrors()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Expected Name, found <EOF>');
         parse('{');
 
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Expected {, found <EOF>');
         parse('query', 'MyQuery.graphql');
     }
@@ -53,7 +53,7 @@ class ParserTest extends TestCase
      */
     public function testParsesConstantDefaultValues()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Unexpected $');
         parse('query Foo($x: Complex = { a: { b: [ $var ] } }) { field }');
         $this->addToAssertionCount(1);
@@ -65,7 +65,7 @@ class ParserTest extends TestCase
      */
     public function testDoesNotAcceptFragmentsNamedOn()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Unexpected Name "on"');
         parse('fragment on on on { on }');
         $this->addToAssertionCount(1);
@@ -77,7 +77,7 @@ class ParserTest extends TestCase
      */
     public function testDoesNotAcceptFragmentSpreadOfOn()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Expected Name, found }');
         parse('{ ...on }');
         $this->addToAssertionCount(1);

--- a/tests/Functional/Language/ParserTest.php
+++ b/tests/Functional/Language/ParserTest.php
@@ -22,10 +22,6 @@ use function Digia\GraphQL\parseValue;
 class ParserTest extends TestCase
 {
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParseProvidesUsefulErrors()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -37,20 +33,12 @@ class ParserTest extends TestCase
         parse('query', 'MyQuery.graphql');
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesVariableInlineValues()
     {
         parse('{ field(complex: { a: { b: [ $var ] } }) }');
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesConstantDefaultValues()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -59,10 +47,6 @@ class ParserTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testDoesNotAcceptFragmentsNamedOn()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -71,10 +55,6 @@ class ParserTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testDoesNotAcceptFragmentSpreadOfOn()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -83,10 +63,6 @@ class ParserTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesMultiByteCharacters()
     {
         /** @var DocumentNode $node */
@@ -119,8 +95,6 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
      * @skipTest
      */
     public function testMultipleFragments()
@@ -361,10 +335,6 @@ class ParserTest extends TestCase
         $this->assertEquals($expected, $node);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesKitchenSink()
     {
         $kitchenSink = mb_convert_encoding(file_get_contents(__DIR__ . '/kitchen-sink.graphql'), 'UTF-8');
@@ -373,10 +343,6 @@ class ParserTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testAllowsNonKeywordsAnywhereANameIsAllowed()
     {
         $nonKeywords = [
@@ -411,10 +377,6 @@ fragment $fragmentName on Type {
         }
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesAnonMutationOperations()
     {
         parse(new Source('
@@ -425,10 +387,6 @@ fragment $fragmentName on Type {
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesAnonSubscriptionOperations()
     {
         parse(new Source('
@@ -439,10 +397,6 @@ fragment $fragmentName on Type {
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesNamedMutationOperations()
     {
         parse(new Source('
@@ -453,10 +407,6 @@ fragment $fragmentName on Type {
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesNamedSubscriptionOperations()
     {
         parse(new Source('
@@ -467,10 +417,6 @@ fragment $fragmentName on Type {
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testCreatesAST()
     {
         /** @var DocumentNode $actual */
@@ -563,10 +509,6 @@ fragment $fragmentName on Type {
         ], $actual->toArray());
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testCreatesAstFromNamelessQueryWithoutVariables()
     {
         /** @var DocumentNode $actual */
@@ -640,10 +582,6 @@ fragment $fragmentName on Type {
 
     // Skip 'contains references to start and end tokens' (not provided by cpp parser)
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesNullValue()
     {
         /** @var NullValueNode $node */
@@ -655,10 +593,6 @@ fragment $fragmentName on Type {
         ]);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesListValue()
     {
         /** @var NullValueNode $node */
@@ -683,10 +617,6 @@ fragment $fragmentName on Type {
         ]);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesBlockStrings()
     {
         /** @var NullValueNode $node */
@@ -713,10 +643,6 @@ fragment $fragmentName on Type {
         ]);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesWellKnownTypes()
     {
         /** @var NamedTypeNode $node */
@@ -733,10 +659,6 @@ fragment $fragmentName on Type {
         ]);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesCustomTypes()
     {
         /** @var NamedTypeNode $node */
@@ -753,10 +675,6 @@ fragment $fragmentName on Type {
         ]);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesListTypes()
     {
         /** @var NamedTypeNode $node */
@@ -777,10 +695,6 @@ fragment $fragmentName on Type {
         ]);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesNonNullTypes()
     {
         /** @var NamedTypeNode $node */
@@ -801,10 +715,6 @@ fragment $fragmentName on Type {
         ]);
     }
 
-    /**
-     * @throws \Digia\GraphQL\Error\ExecutionException
-     * @throws \Exception
-     */
     public function testParsesNestedTypes()
     {
         /** @var NamedTypeNode $node */

--- a/tests/Functional/Language/ParserTest.php
+++ b/tests/Functional/Language/ParserTest.php
@@ -23,7 +23,7 @@ class ParserTest extends TestCase
 {
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParseProvidesUsefulErrors()
@@ -38,7 +38,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesVariableInlineValues()
@@ -48,7 +48,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesConstantDefaultValues()
@@ -60,7 +60,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testDoesNotAcceptFragmentsNamedOn()
@@ -72,7 +72,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testDoesNotAcceptFragmentSpreadOfOn()
@@ -84,7 +84,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesMultiByteCharacters()
@@ -119,7 +119,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      * @skipTest
      */
@@ -362,7 +362,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesKitchenSink()
@@ -374,7 +374,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testAllowsNonKeywordsAnywhereANameIsAllowed()
@@ -412,7 +412,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesAnonMutationOperations()
@@ -426,7 +426,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesAnonSubscriptionOperations()
@@ -440,7 +440,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesNamedMutationOperations()
@@ -454,7 +454,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesNamedSubscriptionOperations()
@@ -468,7 +468,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testCreatesAST()
@@ -564,7 +564,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testCreatesAstFromNamelessQueryWithoutVariables()
@@ -641,7 +641,7 @@ fragment $fragmentName on Type {
     // Skip 'contains references to start and end tokens' (not provided by cpp parser)
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesNullValue()
@@ -656,7 +656,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesListValue()
@@ -684,7 +684,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesBlockStrings()
@@ -714,7 +714,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesWellKnownTypes()
@@ -734,7 +734,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesCustomTypes()
@@ -754,7 +754,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesListTypes()
@@ -778,7 +778,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesNonNullTypes()
@@ -802,7 +802,7 @@ fragment $fragmentName on Type {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
+     * @throws \Digia\GraphQL\Error\ExecutionException
      * @throws \Exception
      */
     public function testParsesNestedTypes()

--- a/tests/Functional/Language/SchemaBuilderTest.php
+++ b/tests/Functional/Language/SchemaBuilderTest.php
@@ -10,9 +10,6 @@ use function Digia\GraphQL\Util\readFile;
 class SchemaBuilderTest extends TestCase
 {
 
-    /**
-     * @throws \Exception
-     */
     public function testBuildsSchema()
     {
         $introspectionQuery = readFile(__DIR__ . '/schema-user-vote.graphqls');

--- a/tests/Functional/Language/SchemaBuilderTest.php
+++ b/tests/Functional/Language/SchemaBuilderTest.php
@@ -13,7 +13,6 @@ class SchemaBuilderTest extends TestCase
     /**
      * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
-     * @throws \TypeError
      */
     public function testBuildsSchema()
     {

--- a/tests/Functional/Language/SchemaBuilderTest.php
+++ b/tests/Functional/Language/SchemaBuilderTest.php
@@ -11,7 +11,6 @@ class SchemaBuilderTest extends TestCase
 {
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testBuildsSchema()

--- a/tests/Functional/Language/SchemaParserTest.php
+++ b/tests/Functional/Language/SchemaParserTest.php
@@ -73,9 +73,6 @@ function inputValueNode($name, $type, $defaultValue, $loc)
 class SchemaParserTest extends TestCase
 {
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleType()
     {
         /** @var DocumentNode $node */
@@ -107,9 +104,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testParsesWithDescriptionString()
     {
         /** @var DocumentNode $node */
@@ -136,9 +130,6 @@ type Hello {
         ], $node->toArray());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testParsesWithDescriptionMultiLineString()
     {
         /** @var DocumentNode $node */
@@ -168,9 +159,6 @@ type Hello {
         ], $node->toArray());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleExtension()
     {
         /** @var DocumentNode $node */
@@ -201,9 +189,6 @@ extend type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExtensionWithoutFields()
     {
         /** @var DocumentNode $node */
@@ -227,9 +212,6 @@ extend type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExtensionWithoutFieldsFollowedByExtension()
     {
         /** @var DocumentNode $node */
@@ -267,9 +249,6 @@ extend type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExtensionWithoutAnythingThrows()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -277,9 +256,6 @@ extend type Hello {
         parse('extend type Hello');
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExtensionsDoNotIncludeDescriptions()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -298,9 +274,6 @@ extend "Description" type Hello {
 }');
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleNonNullType()
     {
         /** @var DocumentNode $node */
@@ -336,9 +309,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleTypeInheritingInterface()
     {
         /** @var DocumentNode $node */
@@ -369,9 +339,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleTypeInheritingMultipleInterface()
     {
         /** @var DocumentNode $node */
@@ -403,9 +370,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleTypeInheritingMultipleInterfaceWithLeadingAmpersand()
     {
         /** @var DocumentNode $node */
@@ -437,9 +401,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSingleValueEnum()
     {
         /** @var DocumentNode $node */
@@ -463,9 +424,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testDoubleValueEnum()
     {
         /** @var DocumentNode $node */
@@ -490,9 +448,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleInterface()
     {
         /** @var DocumentNode $node */
@@ -523,9 +478,6 @@ interface Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function parseSimpleFieldWithArgument()
     {
         /** @var DocumentNode $node */
@@ -565,9 +517,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleFieldWithArgumentWithDefaultValue()
     {
         /** @var DocumentNode $node */
@@ -611,9 +560,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleFieldWithListArgument()
     {
         /** @var DocumentNode $node */
@@ -657,9 +603,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function parseSimpleFieldWithTwoArguments()
     {
         /** @var DocumentNode $node */
@@ -705,9 +648,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleUnion()
     {
         /** @var DocumentNode $node */
@@ -731,9 +671,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleUnionWithTypes()
     {
         /** @var DocumentNode $node */
@@ -758,9 +695,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleUnionWithTypesAndLeadingPipe()
     {
         /** @var DocumentNode $node */
@@ -785,9 +719,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testUnionFailsWithNoTypes()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -795,9 +726,6 @@ type Hello {
         parse('union Hello = |');
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testUnionFailsWithLeadingDoublePipe()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -805,9 +733,6 @@ type Hello {
         parse('union Hello = || Wo | Rld');
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testUnionFailsWithTrailingPipe()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -815,9 +740,6 @@ type Hello {
         parse('union Hello = | Wo | Rld |');
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleScalar()
     {
         /** @var DocumentNode $node */
@@ -838,9 +760,6 @@ type Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleInputObject()
     {
         /** @var DocumentNode $node */
@@ -872,9 +791,6 @@ input Hello {
         ]), $node->toJSON());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSimpleInputObjectWithArgumentsShouldFail()
     {
         $this->expectException(SyntaxErrorException::class);
@@ -885,9 +801,6 @@ input Hello {
 }');
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testDirectiveWithIncorrectLocations()
     {
         $this->expectException(SyntaxErrorException::class);

--- a/tests/Functional/Language/SchemaParserTest.php
+++ b/tests/Functional/Language/SchemaParserTest.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Test\Functional\Language;
 
-use Digia\GraphQL\Error\SyntaxError;
+use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
 use Digia\GraphQL\Language\AST\NodeKindEnum;
 use Digia\GraphQL\Test\TestCase;
@@ -279,7 +279,7 @@ extend type Hello {
      */
     public function testExtensionWithoutAnythingThrows()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Unexpected <EOF>');
         parse('extend type Hello');
     }
@@ -290,7 +290,7 @@ extend type Hello {
      */
     public function testExtensionsDoNotIncludeDescriptions()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Unexpected Name "extend"');
         parse('
 "Description"
@@ -298,7 +298,7 @@ extend type Hello {
   world: String
 }');
 
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Unexpected String "Description"');
         parse('
 extend "Description" type Hello {
@@ -813,7 +813,7 @@ type Hello {
      */
     public function testUnionFailsWithNoTypes()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Expected Name, found <EOF>');
         parse('union Hello = |');
     }
@@ -824,7 +824,7 @@ type Hello {
      */
     public function testUnionFailsWithLeadingDoublePipe()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Expected Name, found |');
         parse('union Hello = || Wo | Rld');
     }
@@ -835,7 +835,7 @@ type Hello {
      */
     public function testUnionFailsWithTrailingPipe()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Expected Name, found <EOF>');
         parse('union Hello = | Wo | Rld |');
     }
@@ -905,7 +905,7 @@ input Hello {
      */
     public function testSimpleInputObjectWithArgumentsShouldFail()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Expected :, found (');
         parse('
 input Hello {
@@ -919,7 +919,7 @@ input Hello {
      */
     public function testDirectiveWithIncorrectLocations()
     {
-        $this->expectException(SyntaxError::class);
+        $this->expectException(SyntaxErrorException::class);
         $this->expectExceptionMessage('Unexpected Name "INCORRECT_LOCATION"');
         parse('
 directive @foo on FIELD | INCORRECT_LOCATION');

--- a/tests/Functional/Language/SchemaParserTest.php
+++ b/tests/Functional/Language/SchemaParserTest.php
@@ -74,7 +74,6 @@ class SchemaParserTest extends TestCase
 {
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleType()
@@ -109,7 +108,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testParsesWithDescriptionString()
@@ -139,7 +137,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testParsesWithDescriptionMultiLineString()
@@ -172,7 +169,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleExtension()
@@ -206,7 +202,6 @@ extend type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testExtensionWithoutFields()
@@ -233,7 +228,6 @@ extend type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testExtensionWithoutFieldsFollowedByExtension()
@@ -274,7 +268,6 @@ extend type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testExtensionWithoutAnythingThrows()
@@ -285,7 +278,6 @@ extend type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testExtensionsDoNotIncludeDescriptions()
@@ -307,7 +299,6 @@ extend "Description" type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleNonNullType()
@@ -346,7 +337,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleTypeInheritingInterface()
@@ -380,7 +370,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleTypeInheritingMultipleInterface()
@@ -415,7 +404,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleTypeInheritingMultipleInterfaceWithLeadingAmpersand()
@@ -450,7 +438,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSingleValueEnum()
@@ -477,7 +464,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testDoubleValueEnum()
@@ -505,7 +491,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleInterface()
@@ -539,7 +524,6 @@ interface Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function parseSimpleFieldWithArgument()
@@ -582,7 +566,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleFieldWithArgumentWithDefaultValue()
@@ -629,7 +612,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleFieldWithListArgument()
@@ -676,7 +658,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function parseSimpleFieldWithTwoArguments()
@@ -725,7 +706,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleUnion()
@@ -752,7 +732,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleUnionWithTypes()
@@ -780,7 +759,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleUnionWithTypesAndLeadingPipe()
@@ -808,7 +786,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testUnionFailsWithNoTypes()
@@ -819,7 +796,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testUnionFailsWithLeadingDoublePipe()
@@ -830,7 +806,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testUnionFailsWithTrailingPipe()
@@ -841,7 +816,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleScalar()
@@ -865,7 +839,6 @@ type Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleInputObject()
@@ -900,7 +873,6 @@ input Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testSimpleInputObjectWithArgumentsShouldFail()
@@ -914,7 +886,6 @@ input Hello {
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testDirectiveWithIncorrectLocations()

--- a/tests/Functional/Language/SchemaPrinterTest.php
+++ b/tests/Functional/Language/SchemaPrinterTest.php
@@ -11,9 +11,6 @@ use function Digia\GraphQL\Util\readFile;
 class SchemaPrinterTest extends TestCase
 {
 
-    /**
-     * @throws \Exception
-     */
     public function testDoesNotAlterAST()
     {
         // This test seems kind of dumb test, but it makes sure that our parser

--- a/tests/Functional/Language/SchemaPrinterTest.php
+++ b/tests/Functional/Language/SchemaPrinterTest.php
@@ -12,7 +12,6 @@ class SchemaPrinterTest extends TestCase
 {
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testDoesNotAlterAST()

--- a/tests/Functional/Language/VisitorTest.php
+++ b/tests/Functional/Language/VisitorTest.php
@@ -26,9 +26,6 @@ use function Digia\GraphQL\Util\readFile;
 class VisitorTest extends TestCase
 {
 
-    /**
-     * @throws \Exception
-     */
     public function testValidatesPathArgument()
     {
         $visited = [];
@@ -64,9 +61,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsEditingANodeBothOnEnterAndOnLeave()
     {
         $ast = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
@@ -106,9 +100,6 @@ class VisitorTest extends TestCase
         $this->assertTrue($editedNode->getConfigValue('didLeave'));
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsEditingTheRootNodeOnEnterAndOnLeave()
     {
         $ast = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
@@ -145,9 +136,6 @@ class VisitorTest extends TestCase
         $this->assertTrue($editedAst->getConfigValue('didLeave'));
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsForEditingOnEnter()
     {
         $ast = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
@@ -179,9 +167,6 @@ class VisitorTest extends TestCase
         );
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsForEditingOnLeave()
     {
         $ast = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
@@ -214,9 +199,6 @@ class VisitorTest extends TestCase
         );
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testVisitsEditedNode()
     {
         $addedField = (new FieldNode([
@@ -251,9 +233,6 @@ class VisitorTest extends TestCase
         $this->assertTrue($didVisitEditedNode);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsSkippingSubTree()
     {
         $visited = [];
@@ -300,9 +279,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsEarlyExitWhileVisiting()
     {
         $visited = [];
@@ -352,9 +328,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsEarlyExitWhileLeaving()
     {
         $visited = [];
@@ -405,9 +378,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsAKindVisitor()
     {
         $visited = [];
@@ -445,10 +415,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws VisitorBreak
-     * @throws \Exception
-     */
     public function testVisitsVariablesDefinedInFragments()
     {
         $visited = [];
@@ -504,9 +470,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testVisitsKitchenSink()
     {
         $visited = [];
@@ -844,9 +807,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testVisitInParallel()
     {
         $visited = [];
@@ -895,9 +855,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsSkippingSubTreeWhenVisitingInParallel()
     {
         $visited = [];
@@ -1003,9 +960,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsEarlyExitWhileEnteringWhenVisitingInParallel()
     {
         $visited = [];
@@ -1056,9 +1010,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsEarlyExitWhileLeavingWhenVisitingInParallel()
     {
         $visited = [];
@@ -1110,9 +1061,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsEarlyExitFromDifferentPointsWhenVisitingInParallel()
     {
         $visited = [];
@@ -1208,9 +1156,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testMaintainsTypeInfoDuringVisit()
     {
         $visited = [];
@@ -1300,10 +1245,6 @@ class VisitorTest extends TestCase
         ], $visited);
     }
 
-    /**
-     * @throws VisitorBreak
-     * @throws \Exception
-     */
     public function testMaintainsTypeInfoDuringEdit()
     {
         $visited = [];

--- a/tests/Functional/Language/VisitorTest.php
+++ b/tests/Functional/Language/VisitorTest.php
@@ -1223,7 +1223,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \TypeError
      * @throws \Exception
      */
     public function testMaintainsTypeInfoDuringVisit()
@@ -1318,7 +1317,6 @@ class VisitorTest extends TestCase
     /**
      * @throws VisitorBreak
      * @throws \Exception
-     * @throws \TypeError
      */
     public function testMaintainsTypeInfoDuringEdit()
     {

--- a/tests/Functional/Language/VisitorTest.php
+++ b/tests/Functional/Language/VisitorTest.php
@@ -27,7 +27,6 @@ class VisitorTest extends TestCase
 {
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testValidatesPathArgument()
@@ -66,7 +65,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsEditingANodeBothOnEnterAndOnLeave()
@@ -109,7 +107,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsEditingTheRootNodeOnEnterAndOnLeave()
@@ -149,7 +146,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsForEditingOnEnter()
@@ -184,7 +180,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsForEditingOnLeave()
@@ -220,7 +215,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testVisitsEditedNode()
@@ -258,7 +252,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsSkippingSubTree()
@@ -308,7 +301,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsEarlyExitWhileVisiting()
@@ -361,7 +353,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsEarlyExitWhileLeaving()
@@ -415,7 +406,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testAllowsAKindVisitor()
@@ -457,7 +447,6 @@ class VisitorTest extends TestCase
 
     /**
      * @throws VisitorBreak
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testVisitsVariablesDefinedInFragments()
@@ -516,7 +505,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testVisitsKitchenSink()
@@ -1016,7 +1004,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws VisitorBreak
      * @throws \Exception
      */
     public function testAllowsEarlyExitWhileEnteringWhenVisitingInParallel()
@@ -1070,7 +1057,6 @@ class VisitorTest extends TestCase
     }
 
     /**
-     * @throws VisitorBreak
      * @throws \Exception
      */
     public function testAllowsEarlyExitWhileLeavingWhenVisitingInParallel()

--- a/tests/Functional/Language/testSchema.php
+++ b/tests/Functional/Language/testSchema.php
@@ -254,7 +254,6 @@ function FurColor(): EnumType
 
 /**
  * @return InputObjectType
- * @throws \TypeError
  */
 function ComplexInput(): InputObjectType
 {
@@ -422,7 +421,6 @@ function QueryRoot(): ObjectType
 
 /**
  * @return SchemaInterface
- * @throws \TypeError
  */
 function testSchema(): SchemaInterface
 {

--- a/tests/Functional/Type/DefinitionTest.php
+++ b/tests/Functional/Type/DefinitionTest.php
@@ -811,18 +811,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
-    public function testRejectsAnInterfaceTypeWithAnIncorrectTypeForResolveType1()
-    {
-        GraphQLInterfaceType([
-            'name'        => 'AnotherInterface',
-            'resolveType' => [],
-            'fields'      => ['f' => ['type' => GraphQLString()]],
-        ]);
-    }
-
     // Type System: Union types must be resolvable
 
     /**
@@ -860,30 +848,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    // TODO: Assess if we want to test "accepts a Union type defining resolveType of Object types defining isTypeOf".
-
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testRejectsAnInterfaceTypeWithAnIncorrectTypeForResolveType2()
-    {
-        $objectWithIsTypeOf = GraphQLObjectType([
-            'name'   => 'ObjectWithIsTypeOf',
-            'fields' => ['f' => ['type' => GraphQLString()]],
-        ]);
-
-        $this->schemaWithField(
-            GraphQLUnionType([
-                'name'        => 'SomeUnion',
-                'resolveType' => [],
-                'types'       => [$objectWithIsTypeOf],
-            ])
-        );
-
-        $this->addToAssertionCount(1);
-    }
-
     // Type System: Scalar types must be serializable
 
     /**
@@ -912,22 +876,6 @@ class DefinitionTest extends TestCase
         $this->schemaWithField(
             GraphQLScalarType([
                 'name' => 'SomeScalar',
-            ])
-        );
-
-        $this->addToAssertionCount(1);
-    }
-
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testRejectsAScalarTypeDefiningSerializeWithAnIncorrectType()
-    {
-        $this->schemaWithField(
-            GraphQLScalarType([
-                'name'      => 'SomeScalar',
-                'serialize' => [],
             ])
         );
 
@@ -999,26 +947,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testRejectsAScalarTypeDefiningParseValueAndParseLiteralWithAnIncorrectType()
-    {
-        $this->schemaWithField(
-            GraphQLScalarType([
-                'name'         => 'SomeScalar',
-                'serialize'    => function () {
-                    return null;
-                },
-                'parseValue'   => [],
-                'parseLiteral' => [],
-            ])
-        );
-
-        $this->addToAssertionCount(1);
-    }
-
     // Type System: Object types must be assertable
 
     /**
@@ -1033,23 +961,6 @@ class DefinitionTest extends TestCase
                 'isTypeOf' => function () {
                     return true;
                 },
-            ])
-        );
-
-        $this->addToAssertionCount(1);
-    }
-
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testRejectsAnObjectWithAnIncorrectTypeForIsTypeOf()
-    {
-        $this->schemaWithField(
-            GraphQLObjectType([
-                'name'     => 'AnotherObject',
-                'fields'   => ['f' => ['type' => GraphQLString()]],
-                'isTypeOf' => [],
             ])
         );
 
@@ -1105,22 +1016,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testRejectsAnUnionTypeWithIncorrectlyTypedTypes()
-    {
-        $this->schemaWithField(
-            GraphQLUnionType([
-                'name'  => 'AnotherObject',
-                'types' => 1,
-            ])
-        );
-
-        $this->addToAssertionCount(1);
-    }
-
     // Type System: Input Objects must have fields
 
     /**
@@ -1151,40 +1046,6 @@ class DefinitionTest extends TestCase
 
         $field = $inputObjectType->getFields()['f'];
         $this->assertEquals(GraphQLString(), $field->getType());
-    }
-
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testRejectsAnInputObjectTypeWithIncorrectFields()
-    {
-        $inputObjectType = GraphQLInputObjectType([
-            'name'   => 'SomeInputObject',
-            'fields' => 1,
-        ]);
-
-        $inputObjectType->getFields();
-
-        $this->addToAssertionCount(1);
-    }
-
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testRejectsAnInputObjectTypeWithFieldsFunctionThatReturnsIncorrectType()
-    {
-        $inputObjectType = GraphQLInputObjectType([
-            'name'   => 'SomeInputObject',
-            'fields' => function () {
-                return 1;
-            },
-        ]);
-
-        $inputObjectType->getFields();
-
-        $this->addToAssertionCount(1);
     }
 
     // Type System: Input Object fields must not have resolvers
@@ -1316,20 +1177,6 @@ class DefinitionTest extends TestCase
         }
 
         $this->addToAssertionCount(9);
-    }
-
-    /**
-     * @expectedException \TypeError
-     */
-    public function testListMustNotAcceptNonTypes()
-    {
-        $nonTypes = [[], '', null];
-
-        foreach ($nonTypes as $nonType) {
-            GraphQLList($nonType);
-        }
-
-        $this->addToAssertionCount(3);
     }
 
     // Type System: NonNull must only accept non-nullable types

--- a/tests/Functional/Type/DefinitionTest.php
+++ b/tests/Functional/Type/DefinitionTest.php
@@ -185,7 +185,6 @@ class DefinitionTest extends TestCase
     /**
      * @param TypeInterface $type
      * @return Schema
-     * @throws \Exception
      */
     protected function schemaWithField(TypeInterface $type): Schema
     {
@@ -203,7 +202,6 @@ class DefinitionTest extends TestCase
     /**
      * @param $resolveValue
      * @return Schema
-     * @throws \Exception
      */
     protected function schemaWithObjectWithFieldResolver($resolveValue): Schema
     {
@@ -229,9 +227,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Example
 
-    /**
-     * @throws \Exception
-     */
     public function testQuerySchema()
     {
         $schema = GraphQLSchema([
@@ -271,9 +266,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals('feed', $feedField->getName());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testMutationSchema()
     {
         $schema = GraphQLSchema([
@@ -289,9 +281,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals('writeArticle', $writeArticleField->getName());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSubscriptionSchema()
     {
         $schema = GraphQLSchema([
@@ -307,9 +296,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals('articleSubscribe', $articleSubscribeField->getName());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testEnumTypeWithDeprecatedValue()
     {
         $enumWithDeprecatedValue = GraphQLEnumType([
@@ -328,9 +314,6 @@ class DefinitionTest extends TestCase
 
     // TODO: Assess if we want to test "defines an enum type with a value of `null` and `undefined`".
 
-    /**
-     * @throws \Exception
-     */
     public function testObjectWithDeprecatedField()
     {
         $typeWithDeprecatedField = GraphQLObjectType([
@@ -352,9 +335,6 @@ class DefinitionTest extends TestCase
         $this->assertEmpty($field->getArguments());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testIncludesNestedInputObjectsInSchemaTypeMap()
     {
         $nestedInputObject = GraphQLInputObjectType([
@@ -396,9 +376,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals($nestedInputObject, $schema->getTypeMap()[$nestedInputObject->getName()]);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testIncludesInterfacePossibleTypesInSchemaTypeMap()
     {
         $someInterface = GraphQLInterfaceType([
@@ -429,9 +406,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals($someSubtype, $schema->getTypeMap()[$someSubtype->getName()]);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testStringifySimpleTypes()
     {
         $this->assertEquals(TypeNameEnum::INT, (string)GraphQLInt());
@@ -449,7 +423,6 @@ class DefinitionTest extends TestCase
     /**
      * @param $type
      * @param $answer
-     * @throws \Exception
      * @dataProvider identifiesInputTypesDataProvider
      */
     public function testIdentifiesInputTypes($type, $answer)
@@ -482,9 +455,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAllowsAThunkForUnionMemberTypes()
     {
         $union = GraphQLUnionType([
@@ -500,9 +470,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals($this->objectType, $types[0]);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testDoesNotMutatePassedFieldDefinitions()
     {
         $fields = [
@@ -595,9 +562,6 @@ class DefinitionTest extends TestCase
 
     // Field arg config must be object
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnObjectTypeWithFieldArgs()
     {
         $objType = GraphQLObjectType([
@@ -618,7 +582,6 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @throws \Exception
      * @expectedException \Exception
      */
     public function testRejectsAnObjectTypeWithIncorrectlyTypedFieldArgs()
@@ -660,9 +623,6 @@ class DefinitionTest extends TestCase
 
     // Object interfaces must be array
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnObjectTypeWithArrayInterfaces()
     {
         $objType = GraphQLObjectType([
@@ -674,9 +634,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals($this->interfaceType, $objType->getInterfaces()[0]);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnObjectTypeWithInterfacesAsAFunctionReturningAnArray()
     {
         $objType = GraphQLObjectType([
@@ -698,9 +655,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Object fields must have valid resolve values
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsALambdaAsAnObjectFieldResolver()
     {
         $this->schemaWithObjectWithFieldResolver(function () {
@@ -712,7 +666,6 @@ class DefinitionTest extends TestCase
 
     /**
      * @expectedException \Exception
-     * @throws \Exception
      */
     public function testRejectsAnEmptyArrayFieldResolver()
     {
@@ -723,7 +676,6 @@ class DefinitionTest extends TestCase
 
     /**
      * @expectedException \Exception
-     * @throws \Exception
      */
     public function testRejectsAnScalarFieldResolver()
     {
@@ -734,9 +686,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Interface types must be resolvable
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnInterfaceTypeDefiningResolveType()
     {
         $anotherInterfaceType = GraphQLInterfaceType([
@@ -758,9 +707,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnInterfaceTypeWithImplementingTypeDefiningIsTypeOf()
     {
         $anotherInterfaceType = GraphQLInterfaceType([
@@ -782,9 +728,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnInterfaceTypeDefiningResolveTypeWithImplementingTypeDefiningIsTypeOf()
     {
         $anotherInterfaceType = GraphQLInterfaceType([
@@ -811,9 +754,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Union types must be resolvable
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsUnionTypeDefiningResolveType()
     {
         $this->schemaWithField(
@@ -826,9 +766,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAUnionOfObjectTypesDefiningIsTypeOf()
     {
         $objectWithIsTypeOf = GraphQLObjectType([
@@ -848,9 +785,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Scalar types must be serializable
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAScalarTypeDefiningSerialize()
     {
         $this->schemaWithField(
@@ -866,7 +800,6 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @throws \Exception
      * @expectedException \Exception
      */
     public function testRejectsAScalarTypeNotDefiningSerialize()
@@ -880,9 +813,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAScalarTypeDefiningParseValueAndParseLiteral()
     {
         $this->schemaWithField(
@@ -904,7 +834,6 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @throws \Exception
      * @expectedException \Exception
      */
     public function testRejectsAScalarTypeDefiningParseValueButNotParseLiteral()
@@ -925,7 +854,6 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @throws \Exception
      * @expectedException \Exception
      */
     public function testRejectsAScalarTypeDefiningParseLiteralButNotParseValue()
@@ -947,9 +875,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Object types must be assertable
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnObjectTypeWithAnIsTypeOfFunction()
     {
         $this->schemaWithField(
@@ -967,9 +892,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Union types must be array
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnUnionTypeWithArrayTypes()
     {
         $this->schemaWithField(
@@ -982,9 +904,6 @@ class DefinitionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnUnionTypeWithFunctionReturningAnArrayOfTypes()
     {
         $this->schemaWithField(
@@ -1000,7 +919,6 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @throws \Exception
      * @expectedException \Exception
      */
     public function testRejectsAnUnionWithoutTypes()
@@ -1016,9 +934,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Input Objects must have fields
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnInputObjectTypeWithFields()
     {
         $inputObjectType = GraphQLInputObjectType([
@@ -1030,9 +945,6 @@ class DefinitionTest extends TestCase
         $this->assertEquals(GraphQLString(), $field->getType());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAnInputObjectTypeWithAFieldFunction()
     {
         $inputObjectType = GraphQLInputObjectType([
@@ -1074,9 +986,6 @@ class DefinitionTest extends TestCase
 
     // Type System: Enum types must be well defined
 
-    /**
-     * @throws \Exception
-     */
     public function testAcceptsAWellDefinedEnumTypeWithEmptyValueDefinition()
     {
         $enumType = GraphQLEnumType([
@@ -1153,9 +1062,6 @@ class DefinitionTest extends TestCase
 
     // Type System: List must accept only types
 
-    /**
-     * @throws \TypeError
-     */
     public function testListMustAcceptOnlyTypes()
     {
         $types = [
@@ -1179,9 +1085,6 @@ class DefinitionTest extends TestCase
 
     // Type System: NonNull must only accept non-nullable types
 
-    /**
-     * @throws \TypeError
-     */
     public function testNonNullMustAcceptOnlyNonNullableTypes()
     {
         $types = [

--- a/tests/Functional/Type/DefinitionTest.php
+++ b/tests/Functional/Type/DefinitionTest.php
@@ -92,7 +92,7 @@ class DefinitionTest extends TestCase
     protected $scalarType;
 
     /**
-     * @throws \TypeError
+     * @inheritdoc
      */
     public function setUp()
     {
@@ -431,7 +431,6 @@ class DefinitionTest extends TestCase
 
     /**
      * @throws \Exception
-     * @throws \TypeError
      */
     public function testStringifySimpleTypes()
     {
@@ -451,7 +450,6 @@ class DefinitionTest extends TestCase
      * @param $type
      * @param $answer
      * @throws \Exception
-     * @throws \TypeError
      * @dataProvider identifiesInputTypesDataProvider
      */
     public function testIdentifiesInputTypes($type, $answer)
@@ -475,7 +473,7 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @expectedException \TypeError
+     * @expectedException \Digia\Graphql\Error\InvalidTypeException
      */
     public function testProhibitsNestingNonNullInsideNonNull()
     {
@@ -1205,7 +1203,7 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @expectedException \TypeError
+     * @expectedException \Digia\Graphql\Error\InvalidTypeException
      */
     public function testNonNullMustNotAcceptNonTypes()
     {

--- a/tests/Functional/Type/EnumTypeTest.php
+++ b/tests/Functional/Type/EnumTypeTest.php
@@ -166,9 +166,6 @@ class EnumTypeTest extends TestCase
 
     // TODO: Add missing tests when possible.
 
-    /**
-     * @throws \Exception
-     */
     public function testPresentsAGetValuesAPIForComplexEnums()
     {
         $values = $this->complexEnum->getValues();
@@ -180,9 +177,6 @@ class EnumTypeTest extends TestCase
         $this->assertEquals($this->complex2, $values[1]->getValue());
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testPresentsAGetValueAPIForComplexEnums()
     {
         $oneValue = $this->complexEnum->getValue('ONE');

--- a/tests/Functional/Type/EnumTypeTest.php
+++ b/tests/Functional/Type/EnumTypeTest.php
@@ -191,15 +191,6 @@ class EnumTypeTest extends TestCase
         $this->assertEquals($this->complex1, $oneValue->getValue());
     }
 
-    /**
-     * @throws \Exception
-     * @expectedException \TypeError
-     */
-    public function testBadUsageOfGetValueAPI()
-    {
-        $this->complexEnum->getValue($this->complex1);
-    }
-
     // TODO: Add test for 'may be internally represented with complex values'.
 
     // TODO: Add test for 'can be introspected without error'.

--- a/tests/Functional/Type/IntrospectionTest.php
+++ b/tests/Functional/Type/IntrospectionTest.php
@@ -23,7 +23,6 @@ class IntrospectionTest extends TestCase
     }
 
     /**
-     * @throws \Digia\GraphQL\Error\GraphQLError
      * @throws \Exception
      */
     public function testExecutesAnIntrospectionQuery()

--- a/tests/Functional/Type/IntrospectionTest.php
+++ b/tests/Functional/Type/IntrospectionTest.php
@@ -22,9 +22,6 @@ class IntrospectionTest extends TestCase
         $this->introspectionQuery = readFile(__DIR__ . '/../../../Resources/introspection.graphql');
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testExecutesAnIntrospectionQuery()
     {
         $emptySchema = GraphQLSchema([

--- a/tests/Functional/Type/PredicateTest.php
+++ b/tests/Functional/Type/PredicateTest.php
@@ -71,9 +71,6 @@ class PredicateTest extends TestCase
         ]);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAssertType()
     {
         assertType(GraphQLString());
@@ -82,9 +79,6 @@ class PredicateTest extends TestCase
         $this->addToAssertionCount(2);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testAssertScalarTypeWithValidTypes()
     {
         assertScalarType(GraphQLString());

--- a/tests/Functional/Type/PredicateTest.php
+++ b/tests/Functional/Type/PredicateTest.php
@@ -84,7 +84,6 @@ class PredicateTest extends TestCase
 
     /**
      * @throws \Exception
-     * @throws \TypeError
      */
     public function testAssertScalarTypeWithValidTypes()
     {
@@ -95,7 +94,6 @@ class PredicateTest extends TestCase
     }
 
     /**
-     * @throws \TypeError
      * @expectedException \Exception
      */
     public function testAssertScalarTypeWithInvalidTypes()

--- a/tests/Functional/Type/SchemaTest.php
+++ b/tests/Functional/Type/SchemaTest.php
@@ -50,7 +50,7 @@ class SchemaTest extends TestCase
     protected $schema;
 
     /**
-     * @throws \TypeError
+     * @inheritdoc
      */
     public function setUp()
     {

--- a/tests/Functional/Type/SchemaTest.php
+++ b/tests/Functional/Type/SchemaTest.php
@@ -140,9 +140,6 @@ class SchemaTest extends TestCase
         $this->schema->isPossibleType($this->interfaceType, $this->implementingType);
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testIncludesInputTypesOnlyUsedInDirectives()
     {
         $typeMap = $this->schema->getTypeMap();

--- a/tests/Functional/Type/SerializationTest.php
+++ b/tests/Functional/Type/SerializationTest.php
@@ -39,7 +39,7 @@ class SerializationTest extends TestCase
     /**
      * @param $value
      * @dataProvider valuesIntCannotRepresentDataProvider
-     * @expectedException \TypeError
+     * @expectedException \@expectedException \Digia\GraphQL\Error\InvalidTypeException
      */
     public function testValuesIntCannotRepresent($value)
     {
@@ -75,7 +75,7 @@ class SerializationTest extends TestCase
     }
 
     /**
-     * @expectedException \TypeError
+     * @expectedException \@expectedException \Digia\GraphQL\Error\InvalidTypeException
      */
     public function testSerializeEmptyStringToInt()
     {
@@ -116,7 +116,7 @@ class SerializationTest extends TestCase
     /**
      * @param $value
      * @dataProvider valuesFloatCannotRepresentDataProvider
-     * @expectedException \TypeError
+     * @expectedException \Digia\GraphQL\Error\InvalidTypeException
      */
     public function testValuesFloatCannotRepresent($value)
     {

--- a/tests/Functional/Type/SerializationTest.php
+++ b/tests/Functional/Type/SerializationTest.php
@@ -14,7 +14,6 @@ class SerializationTest extends TestCase
     /**
      * @param $value
      * @param $answer
-     * @throws \Exception
      * @dataProvider valuesIntCanRepresentDataProvider
      */
     public function testValuesIntCanRepresent($value, $answer)
@@ -65,9 +64,6 @@ class SerializationTest extends TestCase
         ];
     }
 
-    /**
-     * @throws \Exception
-     */
     public function testSerializeBooleanToInt()
     {
         $this->assertEquals(0, GraphQLInt()->serialize(false));
@@ -86,7 +82,6 @@ class SerializationTest extends TestCase
     /**
      * @param $value
      * @param $answer
-     * @throws \Exception
      * @dataProvider valuesFloatCanRepresentDataProvider
      */
     public function testValuesFloatCanRepresent($value, $answer)
@@ -135,7 +130,6 @@ class SerializationTest extends TestCase
     /**
      * @param $value
      * @param $answer
-     * @throws \Exception
      * @dataProvider valuesStringCanRepresentDataProvider
      */
     public function testValuesStringCanRepresent($value, $answer)
@@ -158,7 +152,6 @@ class SerializationTest extends TestCase
     }
 
     /**
-     * @throws \Exception
      * @dataProvider valuesBooleanCanRepresentDataProvider
      */
     public function testValuesBooleanCanRepresent($value, $answer)


### PR DESCRIPTION
There is no a hierarchy like this:

* BaseException
  - InvariantException
  - InvalidTypeException
  - LanguageException
    * SyntaxErrorException (previously SyntaxError)
  - ExecutionException (previously GraphQLError)