### PR TITLE
Simplify unit test using graph helper

### DIFF
--- a/src/Execution/ExecutionStrategy.php
+++ b/src/Execution/ExecutionStrategy.php
@@ -315,7 +315,7 @@ abstract class ExecutionStrategy
         try {
             $args = getArgumentValues($field, $fieldNode, $context->getVariableValues());
 
-            return $resolveFunction($source, $args, $context, $info);
+            return $resolveFunction($source, $args, $context->getContextValue(), $info);
         } catch (\Throwable $error) {
             return $error;
         }

--- a/src/Execution/values.php
+++ b/src/Execution/values.php
@@ -6,7 +6,9 @@ use Digia\GraphQL\Error\ExecutionException;
 use Digia\GraphQL\Error\InvalidTypeException;
 use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Language\AST\Node\ArgumentNode;
+use Digia\GraphQL\Language\AST\Node\DirectiveNode;
 use Digia\GraphQL\Language\AST\Node\DirectivesTrait;
+use Digia\GraphQL\Language\AST\Node\FieldNode;
 use Digia\GraphQL\Language\AST\Node\NamedTypeNode;
 use Digia\GraphQL\Language\AST\Node\NodeInterface;
 use Digia\GraphQL\Language\AST\Node\VariableNode;
@@ -26,7 +28,7 @@ use function Digia\GraphQL\Util\keyMap;
  * @throws InvalidTypeException
  * @throws InvariantException
  */
-function getArgumentValues($definition, NodeInterface $node, array $variableValues = []): array
+function getArgumentValues($definition, $node, array $variableValues = []): array
 {
     $coercedValues       = [];
     $argumentDefinitions = $definition->getArguments();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -113,38 +113,3 @@ function graphql(
             $fieldResolver
         );
 }
-
-/**
- * Note that this is temporary needed
- * We can remove this later
- *
- * @param SchemaInterface $schema
- * @param DocumentNode    $documentNode
- * @param null            $rootValue
- * @param null            $contextValue
- * @param null            $variableValues
- * @param null            $operationName
- * @param callable|null   $fieldResolver
- * @return ExecutionResult
- */
-function execute(
-    SchemaInterface $schema,
-    DocumentNode $documentNode,
-    $rootValue = null,
-    $contextValue = null,
-    $variableValues = [],
-    $operationName = null,
-    callable $fieldResolver = null
-): ExecutionResult
-{
-    return GraphQL::get(ExecutionInterface::class)
-        ->execute(
-            $schema,
-            $documentNode,
-            $rootValue,
-            $contextValue,
-            $variableValues,
-            $operationName,
-            $fieldResolver
-        );
-}

--- a/tests/Functional/Execution/ExecutionTest.php
+++ b/tests/Functional/Execution/ExecutionTest.php
@@ -3,27 +3,14 @@
 namespace Digia\GraphQL\Test\Functional\Execution;
 
 use Digia\GraphQL\Execution\ExecutionResult;
-use Digia\GraphQL\Language\AST\Node\ArgumentNode;
-use Digia\GraphQL\Language\AST\Node\DocumentNode;
-use Digia\GraphQL\Language\AST\Node\FieldNode;
-use Digia\GraphQL\Language\AST\Node\NamedTypeNode;
-use Digia\GraphQL\Language\AST\Node\NameNode;
-use Digia\GraphQL\Language\AST\Node\OperationDefinitionNode;
-use Digia\GraphQL\Language\AST\Node\SelectionSetNode;
-use Digia\GraphQL\Language\AST\Node\StringValueNode;
-use Digia\GraphQL\Language\AST\NodeKindEnum;
-use Digia\GraphQL\Language\Location;
-use Digia\GraphQL\Language\Source;
-use Digia\GraphQL\Language\SourceLocation;
 use Digia\GraphQL\Test\TestCase;
 use Digia\GraphQL\Type\Definition\ObjectType;
 use Digia\GraphQL\Type\Schema;
 use function Digia\GraphQL\graphql;
-use function Digia\GraphQL\execute;
-use function Digia\GraphQL\Type\GraphQLObjectType;
-use function Digia\GraphQL\Type\GraphQLSchema;
 use function Digia\GraphQL\Type\GraphQLInt;
 use function Digia\GraphQL\Type\GraphQLList;
+use function Digia\GraphQL\Type\GraphQLObjectType;
+use function Digia\GraphQL\Type\GraphQLSchema;
 use function Digia\GraphQL\Type\GraphQLString;
 
 class ExecutionTest extends TestCase
@@ -85,7 +72,7 @@ class ExecutionTest extends TestCase
         ]);
 
         $rootValue = 'rootValue';
-        $source  = 'query Example { a }';
+        $source    = 'query Example { a }';
 
         /** @var ExecutionResult $executionResult */
         $result = graphql($schema, $source, $rootValue);
@@ -115,37 +102,8 @@ class ExecutionTest extends TestCase
                 ])
         ]);
 
-        $documentNode = new DocumentNode([
-            'definitions' => [
-                new OperationDefinitionNode([
-                    'kind'                => NodeKindEnum::OPERATION_DEFINITION,
-                    'name'                => new NameNode([
-                        'value' => 'query',
-                    ]),
-                    'selectionSet'        => new SelectionSetNode([
-                        'selections' => [
-                            new FieldNode([
-                                'name'      => new NameNode([
-                                    'value'    => 'hello',
-                                    'location' => new Location(
-                                        15,
-                                        20,
-                                        new Source('query Example {hello}', 'GraphQL', new SourceLocation())
-                                    )
-                                ]),
-                                'arguments' => []
-                            ])
-                        ]
-                    ]),
-                    'operation'           => 'query',
-                    'directives'          => [],
-                    'variableDefinitions' => []
-                ])
-            ],
-        ]);
-
         /** @var ExecutionResult $executionResult */
-        $executionResult = execute($schema, $documentNode);
+        $executionResult = graphql($schema, 'query Greeting {hello}');
 
         $expected = new ExecutionResult(['hello' => 'world'], []);
 
@@ -177,52 +135,11 @@ class ExecutionTest extends TestCase
                 ])
         ]);
 
-        $documentNode = new DocumentNode([
-            'definitions' => [
-                new OperationDefinitionNode([
-                    'kind'                => NodeKindEnum::OPERATION_DEFINITION,
-                    'name'                => new NameNode([
-                        'value' => 'query'
-                    ]),
-                    'selectionSet'        => new SelectionSetNode([
-                        'selections' => [
-                            new FieldNode([
-                                'name'      => new NameNode([
-                                    'value'    => 'greeting',
-                                    'location' => new Location(
-                                        15,
-                                        20,
-                                        new Source('query Hello($name: String) {greeting(name: $name)}', 'GraphQL',
-                                            new SourceLocation())
-                                    )
-                                ]),
-                                'arguments' => [
-                                    new ArgumentNode([
-                                        'name'  => new NameNode([
-                                            'value' => 'name',
-                                        ]),
-                                        'type'  => new NamedTypeNode([
-                                            'name' => new NameNode([
-                                                'value' => 'String',
-                                            ]),
-                                        ]),
-                                        'value' => new StringValueNode([
-                                            'value' => 'Han Solo'
-                                        ])
-                                    ])
-                                ]
-                            ])
-                        ]
-                    ]),
-                    'operation'           => 'query',
-                    'directives'          => [],
-                    'variableDefinitions' => []
-                ])
-            ],
-        ]);
+        $source         = 'query Hello($name: String) {greeting(name: $name)}';
+        $variableValues = ['name' => 'Han Solo'];
 
         /** @var ExecutionResult $executionResult */
-        $executionResult = execute($schema, $documentNode);
+        $executionResult = graphql($schema, $source, '', null, $variableValues);
 
         $expected = new ExecutionResult(['greeting' => 'Hello Han Solo'], []);
 

--- a/tests/Functional/Execution/MutationTest.php
+++ b/tests/Functional/Execution/MutationTest.php
@@ -2,11 +2,14 @@
 
 namespace Digia\GraphQL\Test\Functional\Execution;
 
-use function Digia\GraphQL\execute;
+
 use Digia\GraphQL\Execution\ExecutionResult;
 use Digia\GraphQL\Language\AST\Node\DocumentNode;
 use Digia\GraphQL\Test\TestCase;
 use Digia\GraphQL\Type\Definition\ObjectType;
+
+use function Digia\GraphQL\execute;
+use function Digia\GraphQL\graphql;
 use function Digia\GraphQL\parse;
 use function Digia\GraphQL\Type\GraphQLSchema;
 use function Digia\GraphQL\Type\GraphQLString;
@@ -58,13 +61,6 @@ class MutationTest extends TestCase
      */
     public function testDoesNotIncludeIllegalFieldsInOutput()
     {
-        /** @var DocumentNode $documentNode */
-        $documentNode = parse('
-        mutation M {
-          thisIsIllegalDontIncludeMe
-        }
-        ');
-
         $schema = GraphQLSchema([
             'query'    => new ObjectType([
                 'name'   => 'Q',
@@ -82,7 +78,7 @@ class MutationTest extends TestCase
 
 
         /** @var ExecutionResult $executionResult */
-        $executionResult = execute($schema, $documentNode);
+        $executionResult = graphql($schema, 'mutation M { thisIsIllegalDontIncludeMe }');
 
         $expected = new ExecutionResult([], []);
 

--- a/tests/Functional/Execution/MutationTest.php
+++ b/tests/Functional/Execution/MutationTest.php
@@ -4,13 +4,9 @@ namespace Digia\GraphQL\Test\Functional\Execution;
 
 
 use Digia\GraphQL\Execution\ExecutionResult;
-use Digia\GraphQL\Language\AST\Node\DocumentNode;
 use Digia\GraphQL\Test\TestCase;
 use Digia\GraphQL\Type\Definition\ObjectType;
-
-use function Digia\GraphQL\execute;
 use function Digia\GraphQL\graphql;
-use function Digia\GraphQL\parse;
 use function Digia\GraphQL\Type\GraphQLSchema;
 use function Digia\GraphQL\Type\GraphQLString;
 
@@ -30,24 +26,25 @@ class MutationTest extends TestCase
                         'greeting' => [
                             'type'    => GraphQLString(),
                             'resolve' => function ($source, $args, $context, $info) {
-                                return sprintf('Hello %s.', 'Han Solo');
+                                return sprintf('Hello %s.', $args['name']);
                             },
+                            'args'    => [
+                                'name' => [
+                                    'type' => GraphQLString()
+                                ]
+                            ]
                         ]
                     ]
                 ])
         ]);
 
-        //@TODO Get proper $name variable
-
-        /** @var DocumentNode $documentNode */
-        $documentNode = parse('
+        $source = '
         mutation M($name: String) {
             greeting(name:$name)
-        }
-        ');
+        }';
 
         /** @var ExecutionResult $executionResult */
-        $executionResult = execute($schema, $documentNode);
+        $executionResult = graphql($schema, $source, '', null, ['name' => 'Han Solo']);
 
         $expected = new ExecutionResult([
             'greeting' => 'Hello Han Solo.'

--- a/tests/Functional/Execution/ValuesTest.php
+++ b/tests/Functional/Execution/ValuesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Digia\GraphQL\Test\Functional\Execution;
+
+use Digia\GraphQL\Execution\ExecutionContext;
+use Digia\GraphQL\Language\AST\Node\OperationDefinitionNode;
+use Digia\GraphQL\Test\TestCase;
+use function Digia\GraphQL\Execution\getArgumentValues;
+use function Digia\GraphQL\parse;
+use function Digia\GraphQL\Type\GraphQLObjectType;
+use function Digia\GraphQL\Type\GraphQLSchema;
+use function Digia\GraphQL\Type\GraphQLString;
+
+class ValuesTest extends TestCase
+{
+    /**
+     * @throws \Digia\GraphQL\Error\ExecutionException
+     * @throws \Digia\GraphQL\Error\InvalidTypeException
+     * @throws \Digia\GraphQL\Error\InvariantException
+     */
+    public function testGetValues()
+    {
+        $schema = GraphQLSchema([
+            'query' =>
+                GraphQLObjectType([
+                    'name'   => 'Greeting',
+                    'fields' => [
+                        'greeting' => [
+                            'type' => GraphQLString(),
+                            'args' => [
+                                'name' => [
+                                    'type' => GraphQLString(),
+                                ]
+                            ]
+                        ]
+                    ]
+                ])
+        ]);
+
+
+        $documentNode = parse('query Hello($name: String) { Greeting(name: $name) }');
+        $operation  = $documentNode->getDefinitions()[0];
+        $node       = $documentNode->getDefinitions()[0]->getSelectionSet()->getSelections()[0];
+        $definition = $schema->getQuery()->getFields()['greeting'];
+
+        $context = new ExecutionContext(
+            $schema, [], null, null, ['name' => 'Han Solo'], null, $operation, []
+        );
+
+        $args = getArgumentValues($definition, $node, $context->getVariableValues());
+
+        $this->assertEquals(['name' => 'Han Solo'], $args);
+    }
+}


### PR DESCRIPTION
- Change all tests to use `graphql()` helper
- Remove `execute()` helper