### PR TITLE
Refactor public API

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -115,7 +115,7 @@ class GraphQL
      * @param array  $args
      * @return mixed
      */
-    public static function get(string $id, array $args = [])
+    public static function make(string $id, array $args = [])
     {
         return static::getInstance()
             ->getContainer()
@@ -131,7 +131,7 @@ class GraphQL
      */
     public static function buildSchema($source, array $resolverMaps = [], array $options = []): SchemaInterface
     {
-        return static::get(SchemaBuilderInterface::class)
+        return static::make(SchemaBuilderInterface::class)
             ->build(
                 static::parse($source, $options),
                 $resolverMaps,
@@ -145,7 +145,7 @@ class GraphQL
      */
     public static function validateSchema(SchemaInterface $schema): array
     {
-        return static::get(SchemaValidatorInterface::class)
+        return static::make(SchemaValidatorInterface::class)
             ->validate($schema);
     }
 
@@ -157,7 +157,7 @@ class GraphQL
      */
     public static function parse($source, array $options = []): DocumentNode
     {
-        return static::get(ParserInterface::class)
+        return static::make(ParserInterface::class)
             ->parse(static::lex($source, $options));
     }
 
@@ -169,7 +169,7 @@ class GraphQL
      */
     public static function parseValue($source, array $options = []): ValueNodeInterface
     {
-        return static::get(ParserInterface::class)
+        return static::make(ParserInterface::class)
             ->parseValue(static::lex($source, $options));
     }
 
@@ -181,7 +181,7 @@ class GraphQL
      */
     public static function parseType($source, array $options = []): TypeNodeInterface
     {
-        return static::get(ParserInterface::class)
+        return static::make(ParserInterface::class)
             ->parseType(static::lex($source, $options));
     }
 
@@ -192,7 +192,7 @@ class GraphQL
      */
     public static function validate(SchemaInterface $schema, DocumentNode $document): array
     {
-        return static::get(ValidatorInterface::class)
+        return static::make(ValidatorInterface::class)
             ->validate($schema, $document);
     }
 
@@ -215,7 +215,7 @@ class GraphQL
         $operationName = null,
         callable $fieldResolver = null
     ): ExecutionResult {
-        return static::get(ExecutionInterface::class)
+        return static::make(ExecutionInterface::class)
             ->execute(
                 $schema,
                 $document,
@@ -233,7 +233,7 @@ class GraphQL
      */
     public static function print(NodeInterface $node): string
     {
-        return static::get(PrinterInterface::class)->print($node);
+        return static::make(PrinterInterface::class)->print($node);
     }
 
     /**
@@ -244,7 +244,7 @@ class GraphQL
      */
     public static function lex($source, array $options = []): LexerInterface
     {
-        return static::get(LexerInterface::class)
+        return static::make(LexerInterface::class)
             ->setSource($source instanceof Source ? $source : new Source($source))
             ->setOptions($options);
     }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -3,17 +3,32 @@
 namespace Digia\GraphQL;
 
 use Digia\GraphQL\Cache\CacheProvider;
+use Digia\GraphQL\Error\InvariantException;
+use Digia\GraphQL\Execution\ExecutionInterface;
 use Digia\GraphQL\Execution\ExecutionProvider;
+use Digia\GraphQL\Execution\ExecutionResult;
 use Digia\GraphQL\Language\LanguageProvider;
+use Digia\GraphQL\Language\LexerInterface;
+use Digia\GraphQL\Language\Node\DocumentNode;
+use Digia\GraphQL\Language\Node\NodeInterface;
+use Digia\GraphQL\Language\Node\TypeNodeInterface;
+use Digia\GraphQL\Language\Node\ValueNodeInterface;
+use Digia\GraphQL\Language\ParserInterface;
+use Digia\GraphQL\Language\PrinterInterface;
+use Digia\GraphQL\Language\Source;
+use Digia\GraphQL\SchemaBuilder\SchemaBuilderInterface;
 use Digia\GraphQL\SchemaBuilder\SchemaBuilderProvider;
+use Digia\GraphQL\SchemaValidator\SchemaValidatorInterface;
 use Digia\GraphQL\SchemaValidator\SchemaValidatorProvider;
 use Digia\GraphQL\Type\CoercerProvider;
 use Digia\GraphQL\Type\DirectivesProvider;
 use Digia\GraphQL\Type\IntrospectionProvider;
 use Digia\GraphQL\Type\ScalarTypesProvider;
+use Digia\GraphQL\Type\SchemaInterface;
 use Digia\GraphQL\Util\UtilityProvider;
 use Digia\GraphQL\Validation\RulesProvider;
 use Digia\GraphQL\Validation\ValidationProvider;
+use Digia\GraphQL\Validation\ValidatorInterface;
 use League\Container\Container;
 use League\Container\ContainerInterface;
 
@@ -84,25 +99,15 @@ class GraphQL
     }
 
     /**
-     * Registers the service provides with the container.
-     */
-    protected function registerProviders(ContainerInterface $container): void
-    {
-        foreach (self::$providers as $className) {
-            $container->addServiceProvider($className);
-        }
-    }
-
-    /**
      * @return GraphQL
      */
     public static function getInstance(): self
     {
-        if (null === self::$instance) {
-            self::$instance = new static();
+        if (null === static::$instance) {
+            static::$instance = new static();
         }
 
-        return self::$instance;
+        return static::$instance;
     }
 
     /**
@@ -112,7 +117,136 @@ class GraphQL
      */
     public static function get(string $id, array $args = [])
     {
-        return self::getInstance()->getContainer()->get($id, $args);
+        return static::getInstance()
+            ->getContainer()
+            ->get($id, $args);
+    }
+
+    /**
+     * @param string|Source $source
+     * @param array         $resolverMaps
+     * @param array         $options
+     * @return SchemaInterface
+     * @throws InvariantException
+     */
+    public static function buildSchema($source, array $resolverMaps = [], array $options = []): SchemaInterface
+    {
+        return static::get(SchemaBuilderInterface::class)
+            ->build(
+                static::parse($source, $options),
+                $resolverMaps,
+                $options
+            );
+    }
+
+    /**
+     * @param SchemaInterface $schema
+     * @return array
+     */
+    public static function validateSchema(SchemaInterface $schema): array
+    {
+        return static::get(SchemaValidatorInterface::class)
+            ->validate($schema);
+    }
+
+    /**
+     * @param string|Source $source
+     * @param array         $options
+     * @return DocumentNode
+     * @throws InvariantException
+     */
+    public static function parse($source, array $options = []): DocumentNode
+    {
+        return static::get(ParserInterface::class)
+            ->parse(static::lex($source, $options));
+    }
+
+    /**
+     * @param string|Source $source
+     * @param array         $options
+     * @return ValueNodeInterface
+     * @throws InvariantException
+     */
+    public static function parseValue($source, array $options = []): ValueNodeInterface
+    {
+        return static::get(ParserInterface::class)
+            ->parseValue(static::lex($source, $options));
+    }
+
+    /**
+     * @param string|Source $source
+     * @param array         $options
+     * @return TypeNodeInterface
+     * @throws InvariantException
+     */
+    public static function parseType($source, array $options = []): TypeNodeInterface
+    {
+        return static::get(ParserInterface::class)
+            ->parseType(static::lex($source, $options));
+    }
+
+    /**
+     * @param SchemaInterface $schema
+     * @param DocumentNode    $document
+     * @return array
+     */
+    public static function validate(SchemaInterface $schema, DocumentNode $document): array
+    {
+        return static::get(ValidatorInterface::class)
+            ->validate($schema, $document);
+    }
+
+    /**
+     * @param SchemaInterface $schema
+     * @param DocumentNode    $document
+     * @param null            $rootValue
+     * @param null            $contextValue
+     * @param array           $variableValues
+     * @param null            $operationName
+     * @param callable|null   $fieldResolver
+     * @return ExecutionResult
+     */
+    public static function execute(
+        SchemaInterface $schema,
+        DocumentNode $document,
+        $rootValue = null,
+        $contextValue = null,
+        array $variableValues = [],
+        $operationName = null,
+        callable $fieldResolver = null
+    ): ExecutionResult {
+        return static::get(ExecutionInterface::class)
+            ->execute(
+                $schema,
+                $document,
+                $rootValue,
+                $contextValue,
+                $variableValues,
+                $operationName,
+                $fieldResolver
+            );
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @return string
+     */
+    public static function print(NodeInterface $node): string
+    {
+        return static::get(PrinterInterface::class)->print($node);
+    }
+
+    /**
+     * @param string|Source $source
+     * @param array         $options
+     * @return LexerInterface
+     * @throws InvariantException
+     */
+    public static function lex($source, array $options = []): LexerInterface
+    {
+        return static::get(LexerInterface::class)
+            ->setSource($source instanceof Source ? $source : new Source($source))
+            ->setOptions($options);
     }
 
     /**
@@ -121,5 +255,15 @@ class GraphQL
     public function getContainer(): Container
     {
         return $this->container;
+    }
+
+    /**
+     * Registers the service provides with the container.
+     */
+    protected function registerProviders(ContainerInterface $container): void
+    {
+        foreach (static::$providers as $className) {
+            $container->addServiceProvider($className);
+        }
     }
 }

--- a/src/SchemaValidator/Rule/SupportedRules.php
+++ b/src/SchemaValidator/Rule/SupportedRules.php
@@ -25,7 +25,7 @@ class SupportedRules
         $rules = [];
 
         foreach (self::$supportedRules as $className) {
-            $rules[] = GraphQL::get($className);
+            $rules[] = GraphQL::make($className);
         }
 
         return $rules;

--- a/src/Type/directives.php
+++ b/src/Type/directives.php
@@ -10,7 +10,7 @@ use function Digia\GraphQL\Util\arraySome;
  */
 function GraphQLIncludeDirective(): Directive
 {
-    return GraphQL::get('GraphQLIncludeDirective');
+    return GraphQL::make('GraphQLIncludeDirective');
 }
 
 /**
@@ -18,7 +18,7 @@ function GraphQLIncludeDirective(): Directive
  */
 function GraphQLSkipDirective(): Directive
 {
-    return GraphQL::get('GraphQLSkipDirective');
+    return GraphQL::make('GraphQLSkipDirective');
 }
 
 const DEFAULT_DEPRECATION_REASON = 'No longer supported';
@@ -28,7 +28,7 @@ const DEFAULT_DEPRECATION_REASON = 'No longer supported';
  */
 function GraphQLDeprecatedDirective(): Directive
 {
-    return GraphQL::get('GraphQLDeprecatedDirective');
+    return GraphQL::make('GraphQLDeprecatedDirective');
 }
 
 /**

--- a/src/Type/introspection.php
+++ b/src/Type/introspection.php
@@ -14,7 +14,7 @@ use function Digia\GraphQL\Util\arraySome;
  */
 function __Schema(): ObjectType
 {
-    return GraphQL::get(GraphQL::SCHEMA_INTROSPECTION);
+    return GraphQL::make(GraphQL::SCHEMA_INTROSPECTION);
 }
 
 /**
@@ -22,7 +22,7 @@ function __Schema(): ObjectType
  */
 function __Directive(): ObjectType
 {
-    return GraphQL::get(GraphQL::DIRECTIVE_INTROSPECTION);
+    return GraphQL::make(GraphQL::DIRECTIVE_INTROSPECTION);
 
 }
 
@@ -31,7 +31,7 @@ function __Directive(): ObjectType
  */
 function __DirectiveLocation(): EnumType
 {
-    return GraphQL::get(GraphQL::DIRECTIVE_LOCATION_INTROSPECTION);
+    return GraphQL::make(GraphQL::DIRECTIVE_LOCATION_INTROSPECTION);
 
 }
 
@@ -40,7 +40,7 @@ function __DirectiveLocation(): EnumType
  */
 function __Type(): ObjectType
 {
-    return GraphQL::get(GraphQL::TYPE_INTROSPECTION);
+    return GraphQL::make(GraphQL::TYPE_INTROSPECTION);
 }
 
 /**
@@ -48,7 +48,7 @@ function __Type(): ObjectType
  */
 function __Field(): ObjectType
 {
-    return GraphQL::get(GraphQL::FIELD_INTROSPECTION);
+    return GraphQL::make(GraphQL::FIELD_INTROSPECTION);
 }
 
 /**
@@ -56,7 +56,7 @@ function __Field(): ObjectType
  */
 function __InputValue(): ObjectType
 {
-    return GraphQL::get(GraphQL::INPUT_VALUE_INTROSPECTION);
+    return GraphQL::make(GraphQL::INPUT_VALUE_INTROSPECTION);
 }
 
 /**
@@ -64,7 +64,7 @@ function __InputValue(): ObjectType
  */
 function __EnumValue(): ObjectType
 {
-    return GraphQL::get(GraphQL::ENUM_VALUE_INTROSPECTION);
+    return GraphQL::make(GraphQL::ENUM_VALUE_INTROSPECTION);
 }
 
 /**
@@ -72,7 +72,7 @@ function __EnumValue(): ObjectType
  */
 function __TypeKind(): EnumType
 {
-    return GraphQL::get(GraphQL::TYPE_KIND_INTROSPECTION);
+    return GraphQL::make(GraphQL::TYPE_KIND_INTROSPECTION);
 }
 
 /**
@@ -80,7 +80,7 @@ function __TypeKind(): EnumType
  */
 function SchemaMetaFieldDefinition(): Field
 {
-    return GraphQL::get(GraphQL::SCHEMA_META_FIELD_DEFINITION);
+    return GraphQL::make(GraphQL::SCHEMA_META_FIELD_DEFINITION);
 }
 
 /**
@@ -88,7 +88,7 @@ function SchemaMetaFieldDefinition(): Field
  */
 function TypeMetaFieldDefinition(): Field
 {
-    return GraphQL::get(GraphQL::TYPE_META_FIELD_DEFINITION);
+    return GraphQL::make(GraphQL::TYPE_META_FIELD_DEFINITION);
 }
 
 /**
@@ -96,7 +96,7 @@ function TypeMetaFieldDefinition(): Field
  */
 function TypeNameMetaFieldDefinition(): Field
 {
-    return GraphQL::get(GraphQL::TYPE_NAME_META_FIELD_DEFINITION);
+    return GraphQL::make(GraphQL::TYPE_NAME_META_FIELD_DEFINITION);
 }
 
 /**

--- a/src/Type/scalars.php
+++ b/src/Type/scalars.php
@@ -12,7 +12,7 @@ use function Digia\GraphQL\Util\arraySome;
  */
 function GraphQLBoolean(): ScalarType
 {
-    return GraphQL::get('GraphQLBoolean');
+    return GraphQL::make('GraphQLBoolean');
 }
 
 /**
@@ -20,7 +20,7 @@ function GraphQLBoolean(): ScalarType
  */
 function GraphQLFloat(): ScalarType
 {
-    return GraphQL::get('GraphQLFloat');
+    return GraphQL::make('GraphQLFloat');
 }
 
 /**
@@ -28,7 +28,7 @@ function GraphQLFloat(): ScalarType
  */
 function GraphQLInt(): ScalarType
 {
-    return GraphQL::get('GraphQLInt');
+    return GraphQL::make('GraphQLInt');
 }
 
 /**
@@ -36,7 +36,7 @@ function GraphQLInt(): ScalarType
  */
 function GraphQLID(): ScalarType
 {
-    return GraphQL::get('GraphQLID');
+    return GraphQL::make('GraphQLID');
 }
 
 /**
@@ -44,7 +44,7 @@ function GraphQLID(): ScalarType
  */
 function GraphQLString(): ScalarType
 {
-    return GraphQL::get('GraphQLString');
+    return GraphQL::make('GraphQLString');
 }
 
 /**

--- a/src/Validation/Rule/SupportedRules.php
+++ b/src/Validation/Rule/SupportedRules.php
@@ -47,7 +47,7 @@ class SupportedRules
         $rules = [];
 
         foreach (self::$supportedRules as $className) {
-            $rules[] = GraphQL::get($className);
+            $rules[] = GraphQL::make($className);
         }
 
         return $rules;

--- a/tests/Functional/Execution/ExecutionTest.php
+++ b/tests/Functional/Execution/ExecutionTest.php
@@ -79,9 +79,7 @@ class ExecutionTest extends TestCase
         /** @var ExecutionResult $executionResult */
         $result = graphql($schema, $source, $rootValue);
 
-        $expected = new ExecutionResult(['a' => $rootValue], []);
-
-        $this->assertEquals($expected, $result);
+        $this->assertEquals(['data' => ['a' => $rootValue]], $result);
     }
 
     /**
@@ -107,9 +105,7 @@ class ExecutionTest extends TestCase
         /** @var ExecutionResult $executionResult */
         $executionResult = graphql($schema, 'query Greeting {hello}');
 
-        $expected = new ExecutionResult(['hello' => 'world'], []);
-
-        $this->assertEquals($expected, $executionResult);
+        $this->assertEquals(['data' => ['hello' => 'world']], $executionResult);
     }
 
     /**
@@ -322,9 +318,7 @@ class ExecutionTest extends TestCase
         /** @var ExecutionResult $executionResult */
         $executionResult = graphql($schema, $source, '', null, $variableValues);
 
-        $expected = new ExecutionResult(['greeting' => 'Hello Han Solo'], []);
-
-        $this->assertEquals($expected, $executionResult);
+        $this->assertEquals(['data' => ['greeting' => 'Hello Han Solo']], $executionResult);
     }
 
     /**
@@ -374,15 +368,15 @@ class ExecutionTest extends TestCase
         /** @var ExecutionResult $executionResult */
         $executionResult = graphql($schema, 'query Human {id, type, friends, appearsIn, homePlanet}');
 
-        $expected = new ExecutionResult([
-            'id'         => 1000,
-            'type'       => 'Human',
-            'friends'    => ['1002', '1003', '2000', '2001'],
-            'appearsIn'  => [4, 5, 6],
-            'homePlanet' => 'Tatooine'
-        ], []);
-
-        $this->assertEquals($expected, $executionResult);
+        $this->assertEquals([
+            'data' => [
+                'id'         => 1000,
+                'type'       => 'Human',
+                'friends'    => ['1002', '1003', '2000', '2001'],
+                'appearsIn'  => [4, 5, 6],
+                'homePlanet' => 'Tatooine'
+            ]
+        ], $executionResult);
     }
 
     /**
@@ -441,20 +435,20 @@ SRC;
         /** @var ExecutionResult $executionResult */
         $executionResult = graphql($schema, $source);
 
-        $expected = new ExecutionResult([
-            'a'    => 'Apple',
-            'b'    => 'Banana',
-            'c'    => 'Cherry',
-            'deep' => [
-                'b'      => 'Banana',
-                'c'      => 'Cherry',
-                'deeper' => [
-                    'b' => 'Banana',
-                    'c' => 'Cherry'
+        $this->assertEquals([
+            'data' => [
+                'a'    => 'Apple',
+                'b'    => 'Banana',
+                'c'    => 'Cherry',
+                'deep' => [
+                    'b'      => 'Banana',
+                    'c'      => 'Cherry',
+                    'deeper' => [
+                        'b' => 'Banana',
+                        'c' => 'Cherry'
+                    ]
                 ]
             ]
-        ], []);
-
-        $this->assertEquals($expected, $executionResult);
+        ], $executionResult);
     }
 }

--- a/tests/Functional/Execution/ValuesResolverTest.php
+++ b/tests/Functional/Execution/ValuesResolverTest.php
@@ -20,7 +20,7 @@ class ValuesResolverTest extends TestCase
 
     public function setUp()
     {
-        $this->valuesResolver = GraphQL::get(ValuesResolver::class);
+        $this->valuesResolver = GraphQL::make(ValuesResolver::class);
     }
 
     /**

--- a/tests/Functional/IntrospectionTest.php
+++ b/tests/Functional/IntrospectionTest.php
@@ -50,7 +50,7 @@ class IntrospectionTest extends TestCase
                     ],
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for query type
@@ -78,7 +78,7 @@ class IntrospectionTest extends TestCase
                     ],
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for a specific type
@@ -102,7 +102,7 @@ class IntrospectionTest extends TestCase
                     'name' => 'Droid',
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for an object kind
@@ -128,7 +128,7 @@ class IntrospectionTest extends TestCase
                     'kind' => 'OBJECT',
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for an interface kind
@@ -154,7 +154,7 @@ class IntrospectionTest extends TestCase
                     'kind' => 'INTERFACE',
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for object fields
@@ -229,7 +229,7 @@ class IntrospectionTest extends TestCase
                     ],
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for nested object fields
@@ -323,7 +323,7 @@ class IntrospectionTest extends TestCase
                     ],
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for field args
@@ -421,7 +421,7 @@ class IntrospectionTest extends TestCase
                     ],
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 
     // Allows querying the schema for documentation
@@ -447,6 +447,6 @@ class IntrospectionTest extends TestCase
                     'description' => 'A mechanical creature in the Star Wars universe.',
                 ],
             ],
-        ], $result->toArray());
+        ], $result);
     }
 }

--- a/tests/Functional/SchemaValidator/ValidationTest.php
+++ b/tests/Functional/SchemaValidator/ValidationTest.php
@@ -42,7 +42,7 @@ class ValidationTest extends TestCase
 
     public function setUp()
     {
-        $this->schemaValidator = GraphQL::get(SchemaValidatorInterface::class);
+        $this->schemaValidator = GraphQL::make(SchemaValidatorInterface::class);
 
         $this->someScalarType = GraphQLScalarType([
             'name'         => 'SomeScalar',

--- a/tests/Functional/Validation/Rule/RuleTestCase.php
+++ b/tests/Functional/Validation/Rule/RuleTestCase.php
@@ -26,8 +26,8 @@ abstract class RuleTestCase extends TestCase
 
     public function setUp()
     {
-        $this->validator = GraphQL::get(ValidatorInterface::class);
-        $this->rule      = GraphQL::get($this->getRuleClassName());
+        $this->validator = GraphQL::make(ValidatorInterface::class);
+        $this->rule      = GraphQL::make($this->getRuleClassName());
     }
 
     protected function expectPassesRule($rule, $query)

--- a/tests/Functional/Validation/ValidationTest.php
+++ b/tests/Functional/Validation/ValidationTest.php
@@ -22,7 +22,7 @@ class ValidationTest extends TestCase
 
     public function setUp()
     {
-        $this->validator = GraphQL::get(ValidatorInterface::class);
+        $this->validator = GraphQL::make(ValidatorInterface::class);
     }
 
     public function testValidatesQueries()


### PR DESCRIPTION
Refactor the public API to make it easier for developers to use the library, even without using the namespaced functions found in [api.php](../tree/master/src/api.php). I also changed the `graphql` function to return an array instead of `ExecutionResult`. This makes testing a bit more simple because we do not have to instantiate new `ExecutionResult` objects to be able to assert results.