### PR TITLE
Missing schema validation tests

### DIFF
--- a/src/Schema/DefinitionBuilder.php
+++ b/src/Schema/DefinitionBuilder.php
@@ -246,9 +246,12 @@ class DefinitionBuilder implements DefinitionBuilderInterface
         return newObjectType([
             'name'        => $node->getNameValue(),
             'description' => $node->getDescriptionValue(),
-            'fields'      => function () use ($node) {
+            'fields'      => $node->hasFields() ? function () use ($node) {
                 return $this->buildFields($node);
-            },
+            } : [],
+            // Note: While this could make early assertions to get the correctly
+            // typed values, that would throw immediately while type system
+            // validation with validateSchema() will produce more actionable results.
             'interfaces'  => function () use ($node) {
                 return $node->hasInterfaces() ? \array_map(function (NodeInterface $interface) {
                     return $this->buildType($interface);
@@ -264,7 +267,7 @@ class DefinitionBuilder implements DefinitionBuilderInterface
      */
     protected function buildFields($node): array
     {
-        return $node->hasFields() ? keyValueMap(
+        return keyValueMap(
             $node->getFields(),
             function ($value) {
                 /** @var FieldDefinitionNode|InputValueDefinitionNode $value */
@@ -278,7 +281,7 @@ class DefinitionBuilder implements DefinitionBuilderInterface
 
                 return $this->buildField($value, $resolve);
             }
-        ) : [];
+        );
     }
 
     /**
@@ -290,9 +293,9 @@ class DefinitionBuilder implements DefinitionBuilderInterface
         return newInterfaceType([
             'name'        => $node->getNameValue(),
             'description' => $node->getDescriptionValue(),
-            'fields'      => function () use ($node): array {
+            'fields'      => $node->hasFields() ? function () use ($node): array {
                 return $this->buildFields($node);
-            },
+            } : [],
             'astNode'     => $node,
         ]);
     }

--- a/src/Schema/Extension/ExtendInfo.php
+++ b/src/Schema/Extension/ExtendInfo.php
@@ -73,7 +73,7 @@ class ExtendInfo
      */
     public function getTypeExtensions(string $typeName): ?array
     {
-        return $this->typeExtensionsMap[$typeName] ?? null;
+        return $this->typeExtensionsMap[$typeName] ?? [];
     }
 
     /**

--- a/src/Schema/Extension/ExtensionContext.php
+++ b/src/Schema/Extension/ExtensionContext.php
@@ -264,14 +264,14 @@ class ExtensionContext implements ExtensionContextInterface
         }
 
         return newInterfaceType([
-            'name'           => $typeName,
-            'description'    => $type->getDescription(),
-            'fields'         => function () use ($type) {
+            'name'              => $typeName,
+            'description'       => $type->getDescription(),
+            'fields'            => function () use ($type) {
                 return $this->extendFieldMap($type);
             },
-            'astNode'        => $type->getAstNode(),
-            'typeExtensions' => $extensionASTNodes,
-            'resolveType'    => $type->getResolveType(),
+            'astNode'           => $type->getAstNode(),
+            'extensionASTNodes' => $extensionASTNodes,
+            'resolveType'       => $type->getResolveType(),
         ]);
     }
 

--- a/src/Schema/Validation/Rule/TypesRule.php
+++ b/src/Schema/Validation/Rule/TypesRule.php
@@ -543,15 +543,16 @@ class TypesRule extends AbstractRule
      */
     protected function getAllObjectOrInterfaceNodes(NamedTypeInterface $type): array
     {
-        $node = $type->getAstNode();
+        $node              = $type->getAstNode();
+        $extensionASTNodes = $type->getExtensionAstNodes();
 
         if (null !== $node) {
-            return $type->hasExtensionAstNodes()
-                ? \array_merge([$node], $type->getExtensionAstNodes())
+            return !empty($extensionASTNodes)
+                ? \array_merge([$node], $extensionASTNodes)
                 : [$node];
         }
 
-        return $type->hasExtensionAstNodes() ? $type->getExtensionAstNodes() : [];
+        return $extensionASTNodes;
     }
 
     /**


### PR DESCRIPTION
Add missing schema validation tests that were initially skipped because we did not support schema extension back when they were written.