### PR TITLE
Experiment: Lex using regex

### DIFF
--- a/src/Error/GraphQLException.php
+++ b/src/Error/GraphQLException.php
@@ -152,7 +152,7 @@ class GraphQLException extends AbstractException implements SerializationInterfa
      */
     public function getLocationsAsArray(): ?array
     {
-        return !empty($this->locations) ? array_map(function (SourceLocation $location) {
+        return !empty($this->locations) ? \array_map(function (SourceLocation $location) {
             return $location->toArray();
         }, $this->locations) : null;
     }
@@ -222,7 +222,7 @@ class GraphQLException extends AbstractException implements SerializationInterfa
     protected function resolvePositions(?array $positions)
     {
         if (null === $positions && !empty($this->nodes)) {
-            $positions = array_reduce($this->nodes, function (array $list, ?NodeInterface $node) {
+            $positions = \array_reduce($this->nodes, function (array $list, ?NodeInterface $node) {
                 if (null !== $node) {
                     $location = $node->getLocation();
                     if (null !== $location) {
@@ -250,11 +250,11 @@ class GraphQLException extends AbstractException implements SerializationInterfa
     protected function resolveLocations(?array $positions, ?Source $source)
     {
         if (null !== $positions && null !== $source) {
-            $locations = array_map(function ($position) use ($source) {
+            $locations = \array_map(function ($position) use ($source) {
                 return SourceLocation::fromSource($source, $position);
             }, $positions);
         } elseif (!empty($this->nodes)) {
-            $locations = array_reduce($this->nodes, function (array $list, NodeInterface $node) {
+            $locations = \array_reduce($this->nodes, function (array $list, NodeInterface $node) {
                 $location = $node->getLocation();
                 if (null !== $location) {
                     $list[] = SourceLocation::fromSource($location->getSource(), $location->getStart());

--- a/src/Language/ASTBuilder.php
+++ b/src/Language/ASTBuilder.php
@@ -987,20 +987,11 @@ class ASTBuilder implements ASTBuilderInterface
         $token = $this->expect($lexer, TokenKindEnum::NAME);
         $value = $token->getValue();
 
-        if ($this->isOperation($value)) {
+        if (isOperation($value)) {
             return $value;
         }
 
         throw $this->unexpected($lexer, $token);
-    }
-
-    /**
-     * @param string $value
-     * @return bool
-     */
-    protected function isOperation(string $value): bool
-    {
-        return \in_array($value, ['query', 'mutation', 'subscription'], true);
     }
 
     /**

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -7,7 +7,6 @@ use Digia\GraphQL\Error\SyntaxErrorException;
 
 class Lexer implements LexerInterface
 {
-
     /**
      * @var Source|null
      */
@@ -31,6 +30,16 @@ class Lexer implements LexerInterface
      * @var Token
      */
     protected $token;
+
+    /**
+     * @var int
+     */
+    protected $cursor;
+
+    /**
+     * @var int
+     */
+    protected $end;
 
     /**
      * The (1-indexed) line containing the current token.
@@ -184,6 +193,8 @@ class Lexer implements LexerInterface
      */
     protected function readToken(Token $prev): Token
     {
+        // TODO: Consider replacing "\r\n" and "\r" with "\n"
+        // TODO: Consider injecting these as arguments
         $body       = $this->source->getBody();
         $bodyLength = \mb_strlen($body);
 
@@ -195,9 +206,7 @@ class Lexer implements LexerInterface
             return new Token(TokenKindEnum::EOF, $bodyLength, $bodyLength, $line, $col, $prev);
         }
 
-        $code = charCodeAt($body, $pos);
-
-        $token = $this->reader->read($body, $bodyLength, $code, $pos, $line, $col, $prev);
+        $token = $this->reader->read($body, $pos, $line, $col, $prev);
 
         if (null !== $token) {
             return $token;

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -63,6 +63,7 @@ class Lexer implements LexerInterface
         $startOfFileToken = new Token(TokenKindEnum::SOF);
 
         $reader->setLexer($this);
+
         $this->reader    = $reader;
         $this->lastToken = $startOfFileToken;
         $this->token     = $startOfFileToken;
@@ -177,24 +178,6 @@ class Lexer implements LexerInterface
     }
 
     /**
-     * @param int   $code
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     * @throws SyntaxErrorException
-     */
-    public function read(int $code, int $pos, int $line, int $col, Token $prev): Token
-    {
-        if ($token = $this->reader->read($code, $pos, $line, $col, $prev)) {
-            return $token;
-        }
-
-        throw new SyntaxErrorException($this->source, $pos, $this->unexpectedCharacterMessage($code));
-    }
-
-    /**
      * @param Token $prev
      * @return Token
      * @throws SyntaxErrorException
@@ -202,7 +185,7 @@ class Lexer implements LexerInterface
     protected function readToken(Token $prev): Token
     {
         $body       = $this->source->getBody();
-        $bodyLength = mb_strlen($body);
+        $bodyLength = \mb_strlen($body);
 
         $pos  = $this->positionAfterWhitespace($body, $prev->getEnd());
         $line = $this->line;
@@ -214,29 +197,33 @@ class Lexer implements LexerInterface
 
         $code = charCodeAt($body, $pos);
 
-        if (isSourceCharacter($code)) {
-            throw new SyntaxErrorException(
-                $this->source,
-                $pos,
-                sprintf('Cannot contain the invalid character %s', printCharCode($code))
-            );
+        $token = $this->reader->read($body, $bodyLength, $code, $pos, $line, $col, $prev);
+
+        if (null !== $token) {
+            return $token;
         }
 
-        return $this->read($code, $pos, $line, $col, $prev);
+        throw new SyntaxErrorException($this->source, $pos, $this->unexpectedCharacterMessage($code));
     }
 
     /**
+     * Report a message that an unexpected character was encountered.
+     *
      * @param int $code
      * @return string
      */
     protected function unexpectedCharacterMessage(int $code): string
     {
+        if (isSourceCharacter($code) && !isLineTerminator($code)) {
+            return \sprintf('Cannot contain the invalid character %s.', printCharCode($code));
+        }
+
         if ($code === 39) {
             // '
             return 'Unexpected single quote character (\'), did you mean to use a double quote (")?';
         }
 
-        return sprintf('Cannot parse the unexpected character %s', printCharCode($code));
+        return \sprintf('Cannot parse the unexpected character %s.', printCharCode($code));
     }
 
     /**
@@ -246,21 +233,21 @@ class Lexer implements LexerInterface
      */
     protected function positionAfterWhitespace(string $body, int $startPosition): int
     {
-        $bodyLength = mb_strlen($body);
+        $bodyLength = \mb_strlen($body);
         $pos        = $startPosition;
 
         while ($pos < $bodyLength) {
-            $code = charCodeAt($body, $pos);
+            $code = charCodeAt($body, $pos, true/* $convertEncoding */);
 
             if ($code === 9 || $code === 32 || $code === 44 || $code === 0xfeff) {
                 // tab | space | comma | BOM
                 ++$pos;
             } elseif ($code === 10) {
-                // new line
+                // new line (\n)
                 ++$pos;
                 $this->advanceLine($pos);
             } elseif ($code === 13) {
-                // carriage return
+                // carriage return (\r)
                 if (charCodeAt($body, $pos + 1) === 10) {
                     $pos += 2;
                 } else {
@@ -278,7 +265,7 @@ class Lexer implements LexerInterface
     /**
      * @param int $pos
      */
-    protected function advanceLine(int $pos)
+    protected function advanceLine(int $pos): void
     {
         ++$this->line;
         $this->lineStart = $pos;

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -237,7 +237,7 @@ class Lexer implements LexerInterface
         $pos        = $startPosition;
 
         while ($pos < $bodyLength) {
-            $code = charCodeAt($body, $pos, true/* $convertEncoding */);
+            $code = charCodeAt($body, $pos);
 
             if ($code === 9 || $code === 32 || $code === 44 || $code === 0xfeff) {
                 // tab | space | comma | BOM

--- a/src/Language/SourceLocation.php
+++ b/src/Language/SourceLocation.php
@@ -57,11 +57,12 @@ class SourceLocation implements SerializationInterface
         $line    = 1;
         $column  = $position + 1;
         $matches = [];
-        preg_match_all("/\r\n|[\n\r]/", mb_substr($source->getBody(), 0, $position), $matches, PREG_OFFSET_CAPTURE);
+
+        \preg_match_all("/\r\n|[\n\r]/", \mb_substr($source->getBody(), 0, $position), $matches, PREG_OFFSET_CAPTURE);
 
         foreach ($matches[0] as $index => $match) {
             $line   += 1;
-            $column = $position + 1 - ($match[1] + mb_strlen($match[0]));
+            $column = $position + 1 - ($match[1] + \mb_strlen($match[0]));
         }
 
         return new static($line, $column);

--- a/src/Language/SourceLocation.php
+++ b/src/Language/SourceLocation.php
@@ -58,11 +58,11 @@ class SourceLocation implements SerializationInterface
         $column  = $position + 1;
         $matches = [];
 
-        \preg_match_all("/\r\n|[\n\r]/", \mb_substr($source->getBody(), 0, $position), $matches, PREG_OFFSET_CAPTURE);
+        \preg_match_all("/\r\n|[\n\r]/", \substr($source->getBody(), 0, $position), $matches, PREG_OFFSET_CAPTURE);
 
         foreach ($matches[0] as $index => $match) {
             $line   += 1;
-            $column = $position + 1 - ($match[1] + \mb_strlen($match[0]));
+            $column = $position + 1 - ($match[1] + \strlen($match[0]));
         }
 
         return new static($line, $column);

--- a/src/Language/Token.php
+++ b/src/Language/Token.php
@@ -159,9 +159,9 @@ class Token implements SerializationInterface
     {
         return [
             'kind'   => $this->kind,
-            'value'  => $this->value,
             'line'   => $this->line,
             'column' => $this->column,
+            'value'  => $this->value,
         ];
     }
 

--- a/src/Language/TokenReader.php
+++ b/src/Language/TokenReader.php
@@ -143,50 +143,42 @@ class TokenReader implements TokenReaderInterface
       int $col,
       Token $prev
     ): Token {
-        $body = $this->lexer->getBody();
+        $body       = $this->lexer->getBody();
         $bodyLength = mb_strlen($body);
-        $start = $pos;
-        $pos = $start + 3;
+        $start      = $pos;
+        $pos        = $start + 3;
         $chunkStart = $pos;
-        $rawValue = '';
-
-        while ($pos < $bodyLength && ($code = charCodeAt($body,
-            $pos)) !== null) {
+        $rawValue   = '';
+        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null) {
             // Closing Triple-Quote (""")
             if ($this->isTripleQuote($body, $code, $pos)) {
                 $rawValue .= sliceString($body, $chunkStart, $pos);
-
                 return new Token(
-                  TokenKindEnum::BLOCK_STRING,
-                  $start,
-                  $pos + 3,
-                  $line,
-                  $col,
-                  $prev,
-                  blockStringValue($rawValue)
+                    TokenKindEnum::BLOCK_STRING,
+                    $start,
+                    $pos + 3,
+                    $line,
+                    $col,
+                    $prev,
+                    blockStringValue($rawValue)
                 );
             }
-
             if (isSourceCharacter($code)) {
                 throw new SyntaxErrorException(
-                  $this->lexer->getSource(),
-                  $pos,
-                  sprintf('Invalid character within String: %s',
-                    printCharCode($code))
+                    $this->lexer->getSource(),
+                    $pos,
+                    sprintf('Invalid character within String: %s', printCharCode($code))
                 );
             }
-
             if ($this->isEscapedTripleQuote($body, $code, $pos)) {
-                $rawValue .= sliceString($body, $chunkStart, $pos) . '"""';
-                $pos += 4;
+                $rawValue   .= sliceString($body, $chunkStart, $pos) . '"""';
+                $pos        += 4;
                 $chunkStart = $pos;
             } else {
                 ++$pos;
             }
         }
-
-        throw new SyntaxErrorException($this->lexer->getSource(), $pos,
-          'Unterminated string.');
+        throw new SyntaxErrorException($this->lexer->getSource(), $pos, 'Unterminated string.');
     }
 
     /**

--- a/src/Language/TokenReader.php
+++ b/src/Language/TokenReader.php
@@ -33,31 +33,27 @@ class TokenReader implements TokenReaderInterface
 
     /**
      * @inheritdoc
+     * @throws SyntaxErrorException
      */
-    public function read(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
+    public function read(string $body, int $bodyLength, int $code, int $pos, int $line, int $col, Token $prev): ?Token
+    {
         switch ($code) {
             case 33: // !
-                return $this->readBang($code, $pos, $line, $col, $prev);
+                return $this->readBang($pos, $line, $col, $prev);
             case 35: // #
-                return $this->readComment($code, $pos, $line, $col, $prev);
+                return $this->readComment($pos, $line, $col, $prev);
             case 36: // $
-                return $this->readDollar($code, $pos, $line, $col, $prev);
+                return $this->readDollar($pos, $line, $col, $prev);
             case 38: // &
-                return $this->readAmp($code, $pos, $line, $col, $prev);
+                return $this->readAmp($pos, $line, $col, $prev);
             case 58: // :
-                return $this->readColon($code, $pos, $line, $col, $prev);
+                return $this->readColon($pos, $line, $col, $prev);
             case 61: // =
-                return $this->readEquals($code, $pos, $line, $col, $prev);
+                return $this->readEquals($pos, $line, $col, $prev);
             case 64: // @
-                return $this->readAt($code, $pos, $line, $col, $prev);
+                return $this->readAt($pos, $line, $col, $prev);
             case 124: // |
-                return $this->readPipe($code, $pos, $line, $col, $prev);
+                return $this->readPipe($pos, $line, $col, $prev);
             case 40:
             case 41: // ( or )~
                 return $this->readParenthesis($code, $pos, $line, $col, $prev);
@@ -75,83 +71,69 @@ class TokenReader implements TokenReaderInterface
             return $this->readNumber($code, $pos, $line, $col, $prev);
         }
 
-        if ($this->isLetter($code) || $this->isUnderscore($code)) {
-            return $this->readName($code, $pos, $line, $col, $prev);
+        if (isLetter($code) || isUnderscore($code)) {
+            return $this->readName($pos, $line, $col, $prev);
         }
 
-        $body = $this->lexer->getBody();
-
         // Spread: ...
-        if ($code === 46 && charCodeAt($body,
-            $pos + 1) === 46 && charCodeAt($body, $pos + 2) === 46) {
-            return $this->readSpread($code, $pos, $line, $col, $prev);
+        if ($bodyLength > 3 && isSpread($body, $code, $pos)) {
+            return $this->readSpread($pos, $line, $col, $prev);
         }
 
         // String: "([^"\\\u000A\u000D]|(\\(u[0-9a-fA-F]{4}|["\\/bfnrt])))*"
-        if ($code === 34 && charCodeAt($body, $pos + 1) !== 34) {
-            return $this->readString($code, $pos, $line, $col, $prev);
+        if ($bodyLength > 2 && isString($body, $code, $pos)) {
+            return $this->readString($pos, $line, $col, $prev);
         }
 
         // Block String: """("?"?(\\"""|\\(?!=""")|[^"\\]))*"""
-        if ($this->isTripleQuote($body, $code, $pos)) {
-            return $this->readBlockString($code, $pos, $line, $col, $prev);
+        if ($bodyLength > 6 && isTripleQuote($body, $code, $pos)) {
+            return $this->readBlockString($pos, $line, $col, $prev);
         }
+
+        return null;
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readName(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        $body = $this->lexer->getBody();
-        $bodyLength = mb_strlen($body);
-        $start = $pos;
-        $pos = $start + 1;
+    protected function readName(int $pos, int $line, int $col, Token $prev): Token
+    {
+        $body       = $this->lexer->getBody();
+        $bodyLength = \mb_strlen($body);
+        $start      = $pos;
+        $pos        = $start + 1;
 
-        while ($pos !== $bodyLength && ($code = charCodeAt($body,
-            $pos)) !== null && $this->isAlphaNumeric($code)) {
+        while ($pos !== $bodyLength && ($code = charCodeAt($body, $pos)) !== null && isAlphaNumeric($code)) {
             ++$pos;
         }
 
-        return new Token(TokenKindEnum::NAME, $start, $pos, $line, $col, $prev,
-          sliceString($body, $start, $pos));
+        return new Token(TokenKindEnum::NAME, $start, $pos, $line, $col, $prev, sliceString($body, $start, $pos));
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      * @throws SyntaxErrorException
      */
-    protected function readBlockString(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
+    protected function readBlockString(int $pos, int $line, int $col, Token $prev): Token
+    {
         $body       = $this->lexer->getBody();
-        $bodyLength = mb_strlen($body);
+        $bodyLength = \mb_strlen($body);
         $start      = $pos;
         $pos        = $start + 3;
         $chunkStart = $pos;
         $rawValue   = '';
+
         while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null) {
             // Closing Triple-Quote (""")
-            if ($this->isTripleQuote($body, $code, $pos)) {
+            if (isTripleQuote($body, $code, $pos)) {
                 $rawValue .= sliceString($body, $chunkStart, $pos);
                 return new Token(
                     TokenKindEnum::BLOCK_STRING,
@@ -163,14 +145,16 @@ class TokenReader implements TokenReaderInterface
                     blockStringValue($rawValue)
                 );
             }
-            if (isSourceCharacter($code)) {
+
+            if (isSourceCharacter($code) && !isLineTerminator($code)) {
                 throw new SyntaxErrorException(
                     $this->lexer->getSource(),
                     $pos,
-                    sprintf('Invalid character within String: %s', printCharCode($code))
+                    \sprintf('Invalid character within String: %s', printCharCode($code))
                 );
             }
-            if ($this->isEscapedTripleQuote($body, $code, $pos)) {
+
+            if (isEscapedTripleQuote($body, $code, $pos)) {
                 $rawValue   .= sliceString($body, $chunkStart, $pos) . '"""';
                 $pos        += 4;
                 $chunkStart = $pos;
@@ -178,27 +162,23 @@ class TokenReader implements TokenReaderInterface
                 ++$pos;
             }
         }
+
         throw new SyntaxErrorException($this->lexer->getSource(), $pos, 'Unterminated string.');
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $code
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      * @throws SyntaxErrorException
      */
-    protected function readNumber(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        $body = $this->lexer->getBody();
-        $start = $pos;
+    protected function readNumber(int $code, int $pos, int $line, int $col, Token $prev): Token
+    {
+        $body    = $this->lexer->getBody();
+        $start   = $pos;
         $isFloat = false;
 
         if ($code === 45) {
@@ -211,29 +191,28 @@ class TokenReader implements TokenReaderInterface
             $code = charCodeAt($body, ++$pos);
             if (isNumber($code)) {
                 throw new SyntaxErrorException(
-                  $this->lexer->getSource(),
-                  $pos,
-                  sprintf('Invalid number, unexpected digit after 0: %s.',
-                    printCharCode($code))
+                    $this->lexer->getSource(),
+                    $pos,
+                    \sprintf('Invalid number, unexpected digit after 0: %s.', printCharCode($code))
                 );
             }
         } else {
-            $pos = $this->readDigits($code, $pos);
+            $pos  = $this->readDigits($code, $pos);
             $code = charCodeAt($body, $pos);
         }
 
         if ($code === 46) {
             // .
             $isFloat = true;
-            $code = charCodeAt($body, ++$pos);
-            $pos = $this->readDigits($code, $pos);
-            $code = charCodeAt($body, $pos);
+            $code    = charCodeAt($body, ++$pos);
+            $pos     = $this->readDigits($code, $pos);
+            $code    = charCodeAt($body, $pos);
         }
 
         if ($code === 69 || $code === 101) {
             // e or E
             $isFloat = true;
-            $code = charCodeAt($body, ++$pos);
+            $code    = charCodeAt($body, ++$pos);
 
             if ($code === 43 || $code === 45) {
                 // + or -
@@ -244,56 +223,54 @@ class TokenReader implements TokenReaderInterface
         }
 
         return new Token(
-          $isFloat ? TokenKindEnum::FLOAT : TokenKindEnum::INT,
-          $start,
-          $pos,
-          $line,
-          $col,
-          $prev,
-          sliceString($body, $start, $pos)
+            $isFloat ? TokenKindEnum::FLOAT : TokenKindEnum::INT,
+            $start,
+            $pos,
+            $line,
+            $col,
+            $prev,
+            sliceString($body, $start, $pos)
         );
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      * @throws SyntaxErrorException
      */
-    protected function readString(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
+    protected function readString(int $pos, int $line, int $col, Token $prev): Token
+    {
         $body       = $this->lexer->getBody();
-        $bodyLength = mb_strlen($body);
+        $bodyLength = \mb_strlen($body);
         $start      = $pos;
         $pos        = $start + 1;
         $chunkStart = $pos;
         $value      = '';
-        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null && !$this->isLineTerminator($code)) {
+        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null && !isLineTerminator($code)) {
             // Closing Quote (")
             if ($code === 34) {
                 $value .= sliceString($body, $chunkStart, $pos);
                 return new Token(TokenKindEnum::STRING, $start, $pos + 1, $line, $col, $prev, $value);
             }
-            if ($this->isSourceCharacter($code)) {
+
+            if (isSourceCharacter($code)) {
                 throw new SyntaxErrorException(
                     $this->lexer->getSource(),
                     $pos,
-                    sprintf('Invalid character within String: %s', printCharCode($code))
+                    \sprintf('Invalid character within String: %s', printCharCode($code))
                 );
             }
+
             ++$pos;
+
             if ($code === 92) {
                 // \
                 $value .= sliceString($body, $chunkStart, $pos - 1);
                 $code  = charCodeAt($body, $pos);
+
                 switch ($code) {
                     case 34:
                         $value .= '"';
@@ -332,7 +309,7 @@ class TokenReader implements TokenReaderInterface
                             throw new SyntaxErrorException(
                                 $this->lexer->getSource(),
                                 $pos,
-                                sprintf(
+                                \sprintf(
                                     'Invalid character escape sequence: %s',
                                     $unicodeString
                                 )
@@ -345,148 +322,104 @@ class TokenReader implements TokenReaderInterface
                         throw new SyntaxErrorException(
                             $this->lexer->getSource(),
                             $pos,
-                            sprintf('Invalid character escape sequence: \\%s', chr($code))
+                            \sprintf('Invalid character escape sequence: \\%s', \chr($code))
                         );
                 }
+
                 ++$pos;
+
                 $chunkStart = $pos;
             }
         }
-        throw new SyntaxErrorException($this->lexer->getSource(), $pos - 1, 'Unterminated string.');
+
+        throw new SyntaxErrorException($this->lexer->getSource(), $pos, 'Unterminated string.');
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readSpread(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        return new Token(TokenKindEnum::SPREAD, $pos, $pos + 3, $line, $col,
-          $prev);
+    protected function readSpread(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::SPREAD, $pos, $pos + 3, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readDollar(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        return new Token(TokenKindEnum::DOLLAR, $pos, $pos + 1, $line, $col,
-          $prev);
+    protected function readDollar(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::DOLLAR, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readPipe(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        return new Token(TokenKindEnum::PIPE, $pos, $pos + 1, $line, $col,
-          $prev);
+    protected function readPipe(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::PIPE, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $code
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readParenthesis(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
+    protected function readParenthesis(int $code, int $pos, int $line, int $col, Token $prev): Token
+    {
         return $code === 40
-          ? new Token(TokenKindEnum::PAREN_L, $pos, $pos + 1, $line, $col,
-            $prev)
-          : new Token(TokenKindEnum::PAREN_R, $pos, $pos + 1, $line, $col,
-            $prev);
+            ? new Token(TokenKindEnum::PAREN_L, $pos, $pos + 1, $line, $col, $prev)
+            : new Token(TokenKindEnum::PAREN_R, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readEquals(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        return new Token(TokenKindEnum::EQUALS, $pos, $pos + 1, $line, $col,
-          $prev);
+    protected function readEquals(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::EQUALS, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readAt(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
+    protected function readAt(int $pos, int $line, int $col, Token $prev): Token
+    {
         return new Token(TokenKindEnum::AT, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readComment(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        $body = $this->lexer->getBody();
+    protected function readComment(int $pos, int $line, int $col, Token $prev): Token
+    {
+        $body  = $this->lexer->getBody();
         $start = $pos;
 
         do {
@@ -494,115 +427,80 @@ class TokenReader implements TokenReaderInterface
         } while ($code !== null && ($code > 0x001f || $code === 0x0009)); // SourceCharacter but not LineTerminator
 
         return new Token(
-          TokenKindEnum::COMMENT,
-          $start,
-          $pos,
-          $line,
-          $col,
-          $prev,
-          sliceString($body, $start + 1, $pos)
+            TokenKindEnum::COMMENT,
+            $start,
+            $pos,
+            $line,
+            $col,
+            $prev,
+            sliceString($body, $start + 1, $pos)
         );
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readColon(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        return new Token(TokenKindEnum::COLON, $pos, $pos + 1, $line, $col,
-          $prev);
+    protected function readColon(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::COLON, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readAmp(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        return new Token(TokenKindEnum::AMP, $pos, $pos + 1, $line, $col,
-          $prev);
+    protected function readAmp(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::AMP, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readBang(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
-        return new Token(TokenKindEnum::BANG, $pos, $pos + 1, $line, $col,
-          $prev);
+    protected function readBang(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::BANG, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $code
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readBrace(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
+    protected function readBrace(int $code, int $pos, int $line, int $col, Token $prev): Token
+    {
         return $code === 123
-          ? new Token(TokenKindEnum::BRACE_L, $pos, $pos + 1, $line, $col,
-            $prev)
-          : new Token(TokenKindEnum::BRACE_R, $pos, $pos + 1, $line, $col,
-            $prev);
+            ? new Token(TokenKindEnum::BRACE_L, $pos, $pos + 1, $line, $col, $prev)
+            : new Token(TokenKindEnum::BRACE_R, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
+     * @param int   $code
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
      * @param Token $prev
      * @return Token
      */
-    protected function readBracket(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token {
+    protected function readBracket(int $code, int $pos, int $line, int $col, Token $prev): Token
+    {
         return $code === 91
-          ? new Token(TokenKindEnum::BRACKET_L, $pos, $pos + 1, $line, $col,
-            $prev)
-          : new Token(TokenKindEnum::BRACKET_R, $pos, $pos + 1, $line, $col,
-            $prev);
+            ? new Token(TokenKindEnum::BRACKET_L, $pos, $pos + 1, $line, $col, $prev)
+            : new Token(TokenKindEnum::BRACKET_R, $pos, $pos + 1, $line, $col, $prev);
     }
 
     /**
@@ -624,109 +522,9 @@ class TokenReader implements TokenReaderInterface
         }
 
         throw new SyntaxErrorException(
-          $this->lexer->getSource(),
-          $pos,
-          sprintf('Invalid number, expected digit but got: %s',
-            printCharCode($code))
+            $this->lexer->getSource(),
+            $pos,
+            sprintf('Invalid number, expected digit but got: %s', printCharCode($code))
         );
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param int $code
-     * @return bool
-     */
-    protected function isLineTerminator(int $code): bool
-    {
-        return $code === 0x000a || $code === 0x000d;
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param int $code
-     * @return bool
-     */
-    protected function isSourceCharacter(int $code): bool
-    {
-        return $code < 0x0020 && $code !== 0x0009;
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param string $body
-     * @param int $code
-     * @param int $pos
-     * @return bool
-     */
-    protected function isTripleQuote(string $body, int $code, int $pos): bool
-    {
-        return $code === 34 && charCodeAt($body,
-            $pos + 1) === 34 && charCodeAt($body, $pos + 2) === 34; // """
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param string $body
-     * @param int $code
-     * @param int $pos
-     * @return bool
-     */
-    protected function isEscapedTripleQuote(
-      string $body,
-      int $code,
-      int $pos
-    ): bool {
-        return $code === 92 &&
-          charCodeAt($body, $pos + 1) === 34 &&
-          charCodeAt($body, $pos + 2) === 34 &&
-          charCodeAt($body, $pos + 3) === 34;
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param int $code
-     * @return bool
-     */
-    protected function isLetter(int $code): bool
-    {
-        return ($code >= 65 && $code <= 90) || ($code >= 97 && $code <= 122); // a-z or A-Z
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param int $code
-     * @return bool
-     */
-    protected function isNumber(int $code): bool
-    {
-        return $code >= 48 && $code <= 57; // 0-9
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param int $code
-     * @return bool
-     */
-    protected function isUnderscore(int $code): bool
-    {
-        return $code === 95; // _
-    }
-
-    /**
-     * @TODO Move to utils.
-     *
-     * @param int $code
-     * @return bool
-     */
-    protected function isAlphaNumeric(int $code): bool
-    {
-        return $this->isLetter($code) || $this->isNumber($code) || $this->isUnderscore($code);
     }
 }

--- a/src/Language/TokenReader.php
+++ b/src/Language/TokenReader.php
@@ -262,7 +262,7 @@ class TokenReader implements TokenReaderInterface
                 throw new SyntaxErrorException(
                     $this->lexer->getSource(),
                     $pos,
-                    \sprintf('Invalid character within String: %s', printCharCode($code))
+                    \sprintf('Invalid character within String: %s.', printCharCode($code))
                 );
             }
 
@@ -300,21 +300,17 @@ class TokenReader implements TokenReaderInterface
                         break;
                     case 117:
                         // u
-                        $unicodeString = sliceString($body, $pos - 1, $pos + 5);
-                        $charCode      = uniCharCode(
-                            charCodeAt($body, $pos + 1),
-                            charCodeAt($body, $pos + 2),
-                            charCodeAt($body, $pos + 3),
-                            charCodeAt($body, $pos + 4)
-                        );
-                        if ($charCode < 0) {
+                        $unicodeString = sliceString($body, $pos + 1, $pos + 5);
+
+                        if (!\preg_match('/[0-9A-Fa-f]{4}/', $unicodeString)) {
                             throw new SyntaxErrorException(
                                 $this->lexer->getSource(),
                                 $pos,
-                                \sprintf('Invalid character escape sequence: %s.', $unicodeString)
+                                \sprintf('Invalid character escape sequence: \\u%s.', $unicodeString)
                             );
                         }
-                        $value .= $unicodeString;
+
+                        $value .= '\\u' . $unicodeString;
                         $pos   += 4;
                         break;
                     default:

--- a/src/Language/TokenReader.php
+++ b/src/Language/TokenReader.php
@@ -278,39 +278,30 @@ class TokenReader implements TokenReaderInterface
       int $col,
       Token $prev
     ): Token {
-        $body = $this->lexer->getBody();
+        $body       = $this->lexer->getBody();
         $bodyLength = mb_strlen($body);
-        $start = $pos;
-        $pos = $start + 1;
+        $start      = $pos;
+        $pos        = $start + 1;
         $chunkStart = $pos;
-        $value = '';
-
-        while ($pos < $bodyLength && ($code = charCodeAt($body,
-            $pos)) !== null && !$this->isLineTerminator($code)) {
+        $value      = '';
+        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null && !$this->isLineTerminator($code)) {
             // Closing Quote (")
             if ($code === 34) {
                 $value .= sliceString($body, $chunkStart, $pos);
-
-                return new Token(TokenKindEnum::STRING, $start, $pos + 1, $line,
-                  $col, $prev, $value);
+                return new Token(TokenKindEnum::STRING, $start, $pos + 1, $line, $col, $prev, $value);
             }
-
             if ($this->isSourceCharacter($code)) {
                 throw new SyntaxErrorException(
-                  $this->lexer->getSource(),
-                  $pos,
-                  sprintf('Invalid character within String: %s',
-                    printCharCode($code))
+                    $this->lexer->getSource(),
+                    $pos,
+                    sprintf('Invalid character within String: %s', printCharCode($code))
                 );
             }
-
             ++$pos;
-
             if ($code === 92) {
                 // \
-                $value .= sliceString($body, $chunkStart, $pos + 1);
-                $code = charCodeAt($body, $pos);
-
+                $value .= sliceString($body, $chunkStart, $pos - 1);
+                $code  = charCodeAt($body, $pos);
                 switch ($code) {
                     case 34:
                         $value .= '"';
@@ -338,41 +329,38 @@ class TokenReader implements TokenReaderInterface
                         break;
                     case 117:
                         // u
-                        $charCode = uniCharCode(
-                          charCodeAt($body, $pos + 1),
-                          charCodeAt($body, $pos + 2),
-                          charCodeAt($body, $pos + 3),
-                          charCodeAt($body, $pos + 4)
+                        $unicodeString = sliceString($body, $pos - 1, $pos + 5);
+                        $charCode      = uniCharCode(
+                            charCodeAt($body, $pos + 1),
+                            charCodeAt($body, $pos + 2),
+                            charCodeAt($body, $pos + 3),
+                            charCodeAt($body, $pos + 4)
                         );
                         if ($charCode < 0) {
                             throw new SyntaxErrorException(
-                              $this->lexer->getSource(),
-                              $pos,
-                              sprintf(
-                                'Invalid character escape sequence: \\u%s',
-                                sliceString($body, $pos + 1, $pos + 5)
-                              )
+                                $this->lexer->getSource(),
+                                $pos,
+                                sprintf(
+                                    'Invalid character escape sequence: %s',
+                                    $unicodeString
+                                )
                             );
                         }
-                        $value .= chr($charCode);
-                        $pos += 4;
+                        $value .= $unicodeString;
+                        $pos   += 4;
                         break;
                     default:
                         throw new SyntaxErrorException(
-                          $this->lexer->getSource(),
-                          $pos,
-                          sprintf('Invalid character escape sequence: \\%s',
-                            chr($code))
+                            $this->lexer->getSource(),
+                            $pos,
+                            sprintf('Invalid character escape sequence: \\%s', chr($code))
                         );
                 }
-
                 ++$pos;
                 $chunkStart = $pos;
             }
         }
-
-        throw new SyntaxErrorException($this->lexer->getSource(), $pos,
-          'Unterminated string.');
+        throw new SyntaxErrorException($this->lexer->getSource(), $pos - 1, 'Unterminated string.');
     }
 
     /**

--- a/src/Language/TokenReader.php
+++ b/src/Language/TokenReader.php
@@ -6,6 +6,14 @@ use Digia\GraphQL\Error\SyntaxErrorException;
 
 class TokenReader implements TokenReaderInterface
 {
+    protected const PATTERN_COMMENT      = "/#[\u{0009}\u{0020}-\u{FFFF}]*/A";
+    protected const PATTERN_NAME         = '/[_A-Za-z][_0-9A-Za-z]*/A';
+    protected const PATTERN_INT          = '/((?!\.)(-?(0|[1-9][0-9]*)))+$/A';
+    protected const PATTERN_FLOAT        = '/-?(0|[1-9][0-9]*)(\.[0-9]+)?((E|e)(\+|-)?[0-9]+)?/A';
+    protected const PATTERN_SPREAD       = '/\.\.\./A';
+    protected const PATTERN_STRING       = "/\"([^\"\\\u{000A}\u{000D}]|(\\([\u{0020}-\u{FFFF}]|[\"\\/bfnrt]))))*\"/As";
+    protected const PATTERN_BLOCK_STRING = '/"""("?"?(\\"""|\\(?!=""")|[^"\\]))*"""/As';
+    protected const PUNCTUATION          = '!$&:=@|()[]{}';
 
     /**
      * The lexer owning this token reader.
@@ -35,299 +43,101 @@ class TokenReader implements TokenReaderInterface
      * @inheritdoc
      * @throws SyntaxErrorException
      */
-    public function read(string $body, int $bodyLength, int $code, int $pos, int $line, int $col, Token $prev): ?Token
+    public function read(string $body, int $pos, int $line, int $col, Token $prev): ?Token
     {
-        switch ($code) {
-            case 33: // !
-                return $this->readBang($pos, $line, $col, $prev);
-            case 35: // #
-                return $this->readComment($pos, $line, $col, $prev);
-            case 36: // $
-                return $this->readDollar($pos, $line, $col, $prev);
-            case 38: // &
-                return $this->readAmp($pos, $line, $col, $prev);
-            case 58: // :
-                return $this->readColon($pos, $line, $col, $prev);
-            case 61: // =
-                return $this->readEquals($pos, $line, $col, $prev);
-            case 64: // @
-                return $this->readAt($pos, $line, $col, $prev);
-            case 124: // |
-                return $this->readPipe($pos, $line, $col, $prev);
-            case 40:
-            case 41: // ( or )~
-                return $this->readParenthesis($code, $pos, $line, $col, $prev);
-            case 91:
-            case 93: // [ or ]
-                return $this->readBracket($code, $pos, $line, $col, $prev);
-            case 123:
-            case 125: // { or }
-                return $this->readBrace($code, $pos, $line, $col, $prev);
+        if (false !== \strpos(self::PUNCTUATION, $body[$pos])) {
+            return $this->createPunctuation($body, $pos, $line, $col, $prev);
         }
 
-        // Int:   -?(0|[1-9][0-9]*)
-        // Float: -?(0|[1-9][0-9]*)(\.[0-9]+)?((E|e)(+|-)?[0-9]+)?
-        if ($code === 45 || isNumber($code)) {
-            return $this->readNumber($code, $pos, $line, $col, $prev);
+        if (\preg_match(static::PATTERN_COMMENT, $body, $match, null, $pos)) {
+            return $this->createComment($pos, $pos + \mb_strlen($match[0]), $line, $col, $prev, $match[0]);
         }
 
-        // Name: [_A-Za-z][_0-9A-Za-z]*
-        if (isAlphaNumeric($code)) {
-            return $this->readName($body, $bodyLength, $pos, $line, $col, $prev);
+        if (\preg_match(static::PATTERN_NAME, $body, $match, null, $pos)) {
+            return $this->createName($pos, $pos + \mb_strlen($match[0]), $line, $col, $prev, $match[0]);
         }
 
-        // Spread: ...
-        if ($bodyLength >= 3 && isSpread($body, $code, $pos)) {
-            return $this->readSpread($pos, $line, $col, $prev);
+        if (\preg_match(static::PATTERN_INT, $body, $match, null, $pos)) {
+            return $this->createInt($pos, $pos + \mb_strlen($match[0]), $line, $col, $prev, $match[0]);
         }
 
-        // String: "([^"\\\u000A\u000D]|(\\(u[0-9a-fA-F]{4}|["\\/bfnrt])))*"
-        if (isString($body, $code, $pos)) {
-            return $this->readString($body, $bodyLength, $pos, $line, $col, $prev);
+        if (\preg_match(static::PATTERN_FLOAT, $body, $match, null, $pos)) {
+            return $this->createFloat($pos, $pos + \mb_strlen($match[0]), $line, $col, $prev, $match[0]);
         }
 
-        // Block String: """("?"?(\\"""|\\(?!=""")|[^"\\]))*"""
-        if ($bodyLength >= 3 && isTripleQuote($body, $code, $pos)) {
-            return $this->readBlockString($body, $bodyLength, $pos, $line, $col, $prev);
+        if (\preg_match(static::PATTERN_SPREAD, $body, $match, null, $pos)) {
+            return $this->createSpread($pos, $pos + 3, $line, $col, $prev);
+        }
+
+        if (\preg_match(static::PATTERN_STRING, $body, $match, null, $pos)) {
+            return $this->createString($pos, $pos + \mb_strlen($match[0]), $line, $col, $prev, $match[0]);
+        }
+
+        if (\preg_match(static::PATTERN_BLOCK_STRING, $body, $match, null, $pos)) {
+            return $this->createBlockString($pos, $pos + \mb_strlen($match[0]), $line, $col, $prev, $match[0]);
         }
 
         return null;
     }
 
     /**
+     * @param string      $kind
+     * @param int         $start
+     * @param int         $line
+     * @param int         $col
+     * @param Token       $prev
+     * @param null|string $value
+     * @return Token
+     */
+    protected function createToken(
+        string $kind,
+        int $start,
+        int $end,
+        int $line,
+        int $col,
+        Token $prev,
+        ?string $value = null
+    ): Token {
+        return new Token($kind, $start, $end, $line, $col, $prev, $value);
+    }
+
+    /**
      * @param string $body
-     * @param int    $bodyLength
      * @param int    $pos
      * @param int    $line
      * @param int    $col
      * @param Token  $prev
      * @return Token
      */
-    protected function readName(string $body, int $bodyLength, int $pos, int $line, int $col, Token $prev): Token
+    protected function createPunctuation(string $body, int $pos, int $line, int $col, Token $prev): Token
     {
-        $start = $pos;
-        $pos   = $start + 1;
+        $code = \ord($body[$pos]);
 
-        while ($pos !== $bodyLength && ($code = charCodeAt($body, $pos)) !== null && isAlphaNumeric($code)) {
-            ++$pos;
+        switch ($code) {
+            case 33: // !
+                return $this->createBang($pos, $line, $col, $prev);
+            case 36: // $
+                return $this->createDollar($pos, $line, $col, $prev);
+            case 38: // &
+                return $this->createAmp($pos, $line, $col, $prev);
+            case 58: // :
+                return $this->createColon($pos, $line, $col, $prev);
+            case 61: // =
+                return $this->createEquals($pos, $line, $col, $prev);
+            case 64: // @
+                return $this->createAt($pos, $line, $col, $prev);
+            case 124: // |
+                return $this->createPipe($pos, $line, $col, $prev);
+            case 40:
+            case 41: // ( or )~
+                return $this->createParenthesis($code, $pos, $line, $col, $prev);
+            case 91:
+            case 93: // [ or ]
+                return $this->createBracket($code, $pos, $line, $col, $prev);
+            case 123:
+            case 125: // { or }
+                return $this->createBrace($code, $pos, $line, $col, $prev);
         }
-
-        return new Token(TokenKindEnum::NAME, $start, $pos, $line, $col, $prev, sliceString($body, $start, $pos));
-    }
-
-    /**
-     * @param string $body
-     * @param int    $bodyLength
-     * @param int    $pos
-     * @param int    $line
-     * @param int    $col
-     * @param Token  $prev
-     * @return Token
-     * @throws SyntaxErrorException
-     */
-    protected function readBlockString(string $body, int $bodyLength, int $pos, int $line, int $col, Token $prev): Token
-    {
-        $start      = $pos;
-        $pos        = $start + 3;
-        $chunkStart = $pos;
-        $rawValue   = '';
-
-        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null) {
-            // Closing Triple-Quote (""")
-            if (isTripleQuote($body, $code, $pos)) {
-                $rawValue .= sliceString($body, $chunkStart, $pos);
-                return new Token(
-                    TokenKindEnum::BLOCK_STRING,
-                    $start,
-                    $pos + 3,
-                    $line,
-                    $col,
-                    $prev,
-                    blockStringValue($rawValue)
-                );
-            }
-
-            if (isSourceCharacter($code) && !isLineTerminator($code)) {
-                throw new SyntaxErrorException(
-                    $this->lexer->getSource(),
-                    $pos,
-                    \sprintf('Invalid character within String: %s.', printCharCode($code))
-                );
-            }
-
-            if (isEscapedTripleQuote($body, $code, $pos)) {
-                $rawValue   .= sliceString($body, $chunkStart, $pos) . '"""';
-                $pos        += 4;
-                $chunkStart = $pos;
-            } else {
-                ++$pos;
-            }
-        }
-
-        throw new SyntaxErrorException($this->lexer->getSource(), $pos, 'Unterminated string.');
-    }
-
-    /**
-     * @param int   $code
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     * @throws SyntaxErrorException
-     */
-    protected function readNumber(int $code, int $pos, int $line, int $col, Token $prev): Token
-    {
-        $body    = $this->lexer->getBody();
-        $start   = $pos;
-        $isFloat = false;
-
-        if ($code === 45) {
-            // -
-            $code = charCodeAt($body, ++$pos);
-        }
-
-        if ($code === 48) {
-            // 0
-            $code = charCodeAt($body, ++$pos);
-            if (isNumber($code)) {
-                throw new SyntaxErrorException(
-                    $this->lexer->getSource(),
-                    $pos,
-                    \sprintf('Invalid number, unexpected digit after 0: %s.', printCharCode($code))
-                );
-            }
-        } else {
-            $pos  = $this->readDigits($code, $pos);
-            $code = charCodeAt($body, $pos);
-        }
-
-        if ($code === 46) {
-            // .
-            $isFloat = true;
-            $code    = charCodeAt($body, ++$pos);
-            $pos     = $this->readDigits($code, $pos);
-            $code    = charCodeAt($body, $pos);
-        }
-
-        if ($code === 69 || $code === 101) {
-            // e or E
-            $isFloat = true;
-            $code    = charCodeAt($body, ++$pos);
-
-            if ($code === 43 || $code === 45) {
-                // + or -
-                $code = charCodeAt($body, ++$pos);
-            }
-
-            $pos = $this->readDigits($code, $pos);
-        }
-
-        return new Token(
-            $isFloat ? TokenKindEnum::FLOAT : TokenKindEnum::INT,
-            $start,
-            $pos,
-            $line,
-            $col,
-            $prev,
-            sliceString($body, $start, $pos)
-        );
-    }
-
-    /**
-     * @param string $body
-     * @param int    $bodyLength
-     * @param int    $pos
-     * @param int    $line
-     * @param int    $col
-     * @param Token  $prev
-     * @return Token
-     * @throws SyntaxErrorException
-     */
-    protected function readString(string $body, int $bodyLength, int $pos, int $line, int $col, Token $prev): Token
-    {
-        $start      = $pos;
-        $pos        = $start + 1;
-        $chunkStart = $pos;
-        $value      = '';
-
-        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null && !isLineTerminator($code)) {
-            // Closing Quote (")
-            if ($code === 34) {
-                $value .= sliceString($body, $chunkStart, $pos);
-                return new Token(TokenKindEnum::STRING, $start, $pos + 1, $line, $col, $prev, $value);
-            }
-
-            if (isSourceCharacter($code)) {
-                throw new SyntaxErrorException(
-                    $this->lexer->getSource(),
-                    $pos,
-                    \sprintf('Invalid character within String: %s.', printCharCode($code))
-                );
-            }
-
-            ++$pos;
-
-            if ($code === 92) {
-                // \
-                $value .= sliceString($body, $chunkStart, $pos - 1);
-                $code  = charCodeAt($body, $pos);
-
-                switch ($code) {
-                    case 34:
-                        $value .= '"';
-                        break;
-                    case 47:
-                        $value .= '/';
-                        break;
-                    case 92:
-                        $value .= '\\';
-                        break;
-                    case 98:
-                        $value .= '\b';
-                        break;
-                    case 102:
-                        $value .= '\f';
-                        break;
-                    case 110:
-                        $value .= '\n';
-                        break;
-                    case 114:
-                        $value .= '\r';
-                        break;
-                    case 116:
-                        $value .= '\t';
-                        break;
-                    case 117:
-                        // u
-                        $unicodeString = sliceString($body, $pos + 1, $pos + 5);
-
-                        if (!\preg_match('/[0-9A-Fa-f]{4}/', $unicodeString)) {
-                            throw new SyntaxErrorException(
-                                $this->lexer->getSource(),
-                                $pos,
-                                \sprintf('Invalid character escape sequence: \\u%s.', $unicodeString)
-                            );
-                        }
-
-                        $value .= '\\u' . $unicodeString;
-                        $pos   += 4;
-                        break;
-                    default:
-                        throw new SyntaxErrorException(
-                            $this->lexer->getSource(),
-                            $pos,
-                            \sprintf('Invalid character escape sequence: \\%s.', \chr($code))
-                        );
-                }
-
-                ++$pos;
-
-                $chunkStart = $pos;
-            }
-        }
-
-        throw new SyntaxErrorException($this->lexer->getSource(), $pos, 'Unterminated string.');
     }
 
     /**
@@ -337,109 +147,7 @@ class TokenReader implements TokenReaderInterface
      * @param Token $prev
      * @return Token
      */
-    protected function readSpread(int $pos, int $line, int $col, Token $prev): Token
-    {
-        return new Token(TokenKindEnum::SPREAD, $pos, $pos + 3, $line, $col, $prev);
-    }
-
-    /**
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     */
-    protected function readDollar(int $pos, int $line, int $col, Token $prev): Token
-    {
-        return new Token(TokenKindEnum::DOLLAR, $pos, $pos + 1, $line, $col, $prev);
-    }
-
-    /**
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     */
-    protected function readPipe(int $pos, int $line, int $col, Token $prev): Token
-    {
-        return new Token(TokenKindEnum::PIPE, $pos, $pos + 1, $line, $col, $prev);
-    }
-
-    /**
-     * @param int   $code
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     */
-    protected function readParenthesis(int $code, int $pos, int $line, int $col, Token $prev): Token
-    {
-        return $code === 40
-            ? new Token(TokenKindEnum::PAREN_L, $pos, $pos + 1, $line, $col, $prev)
-            : new Token(TokenKindEnum::PAREN_R, $pos, $pos + 1, $line, $col, $prev);
-    }
-
-    /**
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     */
-    protected function readEquals(int $pos, int $line, int $col, Token $prev): Token
-    {
-        return new Token(TokenKindEnum::EQUALS, $pos, $pos + 1, $line, $col, $prev);
-    }
-
-    /**
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     */
-    protected function readAt(int $pos, int $line, int $col, Token $prev): Token
-    {
-        return new Token(TokenKindEnum::AT, $pos, $pos + 1, $line, $col, $prev);
-    }
-
-    /**
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     */
-    protected function readComment(int $pos, int $line, int $col, Token $prev): Token
-    {
-        $body  = $this->lexer->getBody();
-        $start = $pos;
-
-        do {
-            $code = charCodeAt($body, ++$pos);
-        } while ($code !== null && ($code > 0x001f || $code === 0x0009)); // SourceCharacter but not LineTerminator
-
-        return new Token(
-            TokenKindEnum::COMMENT,
-            $start,
-            $pos,
-            $line,
-            $col,
-            $prev,
-            sliceString($body, $start + 1, $pos)
-        );
-    }
-
-    /**
-     * @param int   $pos
-     * @param int   $line
-     * @param int   $col
-     * @param Token $prev
-     * @return Token
-     */
-    protected function readColon(int $pos, int $line, int $col, Token $prev): Token
+    protected function createColon(int $pos, int $line, int $col, Token $prev): Token
     {
         return new Token(TokenKindEnum::COLON, $pos, $pos + 1, $line, $col, $prev);
     }
@@ -451,7 +159,7 @@ class TokenReader implements TokenReaderInterface
      * @param Token $prev
      * @return Token
      */
-    protected function readAmp(int $pos, int $line, int $col, Token $prev): Token
+    protected function createAmp(int $pos, int $line, int $col, Token $prev): Token
     {
         return new Token(TokenKindEnum::AMP, $pos, $pos + 1, $line, $col, $prev);
     }
@@ -463,7 +171,7 @@ class TokenReader implements TokenReaderInterface
      * @param Token $prev
      * @return Token
      */
-    protected function readBang(int $pos, int $line, int $col, Token $prev): Token
+    protected function createBang(int $pos, int $line, int $col, Token $prev): Token
     {
         return new Token(TokenKindEnum::BANG, $pos, $pos + 1, $line, $col, $prev);
     }
@@ -476,7 +184,7 @@ class TokenReader implements TokenReaderInterface
      * @param Token $prev
      * @return Token
      */
-    protected function readBrace(int $code, int $pos, int $line, int $col, Token $prev): Token
+    protected function createBrace(int $code, int $pos, int $line, int $col, Token $prev): Token
     {
         return $code === 123
             ? new Token(TokenKindEnum::BRACE_L, $pos, $pos + 1, $line, $col, $prev)
@@ -491,7 +199,7 @@ class TokenReader implements TokenReaderInterface
      * @param Token $prev
      * @return Token
      */
-    protected function readBracket(int $code, int $pos, int $line, int $col, Token $prev): Token
+    protected function createBracket(int $code, int $pos, int $line, int $col, Token $prev): Token
     {
         return $code === 91
             ? new Token(TokenKindEnum::BRACKET_L, $pos, $pos + 1, $line, $col, $prev)
@@ -499,27 +207,396 @@ class TokenReader implements TokenReaderInterface
     }
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @return int
-     * @throws SyntaxErrorException
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
+     * @param Token $prev
+     * @return Token
      */
-    protected function readDigits(int $code, int $pos): int
+    protected function createDollar(int $pos, int $line, int $col, Token $prev): Token
     {
-        $body = $this->lexer->getBody();
-
-        if (isNumber($code)) {
-            do {
-                $code = charCodeAt($body, ++$pos);
-            } while (isNumber($code));
-
-            return $pos;
-        }
-
-        throw new SyntaxErrorException(
-            $this->lexer->getSource(),
-            $pos,
-            sprintf('Invalid number, expected digit but got: %s.', printCharCode($code))
-        );
+        return new Token(TokenKindEnum::DOLLAR, $pos, $pos + 1, $line, $col, $prev);
     }
+
+    /**
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
+     * @param Token $prev
+     * @return Token
+     */
+    protected function createPipe(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::PIPE, $pos, $pos + 1, $line, $col, $prev);
+    }
+
+    /**
+     * @param int   $code
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
+     * @param Token $prev
+     * @return Token
+     */
+    protected function createParenthesis(int $code, int $pos, int $line, int $col, Token $prev): Token
+    {
+        return $code === 40
+            ? new Token(TokenKindEnum::PAREN_L, $pos, $pos + 1, $line, $col, $prev)
+            : new Token(TokenKindEnum::PAREN_R, $pos, $pos + 1, $line, $col, $prev);
+    }
+
+    /**
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
+     * @param Token $prev
+     * @return Token
+     */
+    protected function createEquals(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::EQUALS, $pos, $pos + 1, $line, $col, $prev);
+    }
+
+    /**
+     * @param int   $pos
+     * @param int   $line
+     * @param int   $col
+     * @param Token $prev
+     * @return Token
+     */
+    protected function createAt(int $pos, int $line, int $col, Token $prev): Token
+    {
+        return new Token(TokenKindEnum::AT, $pos, $pos + 1, $line, $col, $prev);
+    }
+
+    /**
+     * @param array ...$args
+     * @return Token
+     */
+    protected function createComment(...$args): Token
+    {
+        return $this->createToken(TokenKindEnum::COMMENT, ...$args);
+    }
+
+    /**
+     * @param array ...$args
+     * @return Token
+     */
+    protected function createName(...$args): Token
+    {
+        return $this->createToken(TokenKindEnum::NAME, ...$args);
+    }
+
+    /**
+     * @param array ...$args
+     * @return Token
+     */
+    protected function createInt(...$args): Token
+    {
+        return $this->createToken(TokenKindEnum::INT, ...$args);
+    }
+
+    /**
+     * @param array ...$args
+     * @return Token
+     */
+    protected function createFloat(...$args): Token
+    {
+        return $this->createToken(TokenKindEnum::FLOAT, ...$args);
+    }
+
+    /**
+     * @param array ...$args
+     * @return Token
+     */
+    protected function createSpread(...$args): Token
+    {
+        return $this->createToken(TokenKindEnum::SPREAD, ...$args);
+    }
+
+    /**
+     * @param array ...$args
+     * @return Token
+     */
+    protected function createString(...$args): Token
+    {
+        return $this->createToken(TokenKindEnum::STRING, ...$args);
+    }
+
+    /**
+     * @param array ...$args
+     * @return Token
+     */
+    protected function createBlockString(...$args): Token
+    {
+        return $this->createToken(TokenKindEnum::BLOCK_STRING, ...$args);
+    }
+
+//    /**
+//     * @param string $body
+//     * @param int    $bodyLength
+//     * @param int    $pos
+//     * @param int    $line
+//     * @param int    $col
+//     * @param Token  $prev
+//     * @return Token
+//     * @throws SyntaxErrorException
+//     */
+//    protected function readBlockString(string $body, int $bodyLength, int $pos, int $line, int $col, Token $prev): Token
+//    {
+//        $start      = $pos;
+//        $pos        = $start + 3;
+//        $chunkStart = $pos;
+//        $rawValue   = '';
+//
+//        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null) {
+//            // Closing Triple-Quote (""")
+//            if (isTripleQuote($body, $code, $pos)) {
+//                $rawValue .= sliceString($body, $chunkStart, $pos);
+//                return new Token(
+//                    TokenKindEnum::BLOCK_STRING,
+//                    $start,
+//                    $pos + 3,
+//                    $line,
+//                    $col,
+//                    $prev,
+//                    blockStringValue($rawValue)
+//                );
+//            }
+//
+//            if (isSourceCharacter($code) && !isLineTerminator($code)) {
+//                throw new SyntaxErrorException(
+//                    $this->lexer->getSource(),
+//                    $pos,
+//                    \sprintf('Invalid character within String: %s.', printCharCode($code))
+//                );
+//            }
+//
+//            if (isEscapedTripleQuote($body, $code, $pos)) {
+//                $rawValue   .= sliceString($body, $chunkStart, $pos) . '"""';
+//                $pos        += 4;
+//                $chunkStart = $pos;
+//            } else {
+//                ++$pos;
+//            }
+//        }
+//
+//        throw new SyntaxErrorException($this->lexer->getSource(), $pos, 'Unterminated string.');
+//    }
+//
+//    /**
+//     * @param int   $code
+//     * @param int   $pos
+//     * @param int   $line
+//     * @param int   $col
+//     * @param Token $prev
+//     * @return Token
+//     * @throws SyntaxErrorException
+//     */
+//    protected function readNumber(int $code, int $pos, int $line, int $col, Token $prev): Token
+//    {
+//        $body    = $this->lexer->getBody();
+//        $start   = $pos;
+//        $isFloat = false;
+//
+//        if ($code === 45) {
+//            // -
+//            $code = charCodeAt($body, ++$pos);
+//        }
+//
+//        if ($code === 48) {
+//            // 0
+//            $code = charCodeAt($body, ++$pos);
+//
+//            if (isNumber($code)) {
+//                throw new SyntaxErrorException(
+//                    $this->lexer->getSource(),
+//                    $pos,
+//                    \sprintf('Invalid number, unexpected digit after 0: %s.', printCharCode($code))
+//                );
+//            }
+//        } else {
+//            $pos  = $this->readDigits($code, $pos);
+//            $code = charCodeAt($body, $pos);
+//        }
+//
+//        if ($code === 46) {
+//            // .
+//            $isFloat = true;
+//            $code    = charCodeAt($body, ++$pos);
+//            $pos     = $this->readDigits($code, $pos);
+//            $code    = charCodeAt($body, $pos);
+//        }
+//
+//        if ($code === 69 || $code === 101) {
+//            // e or E
+//            $isFloat = true;
+//            $code    = charCodeAt($body, ++$pos);
+//
+//            if ($code === 43 || $code === 45) {
+//                // + or -
+//                $code = charCodeAt($body, ++$pos);
+//            }
+//
+//            $pos = $this->readDigits($code, $pos);
+//        }
+//
+//        return new Token(
+//            $isFloat ? TokenKindEnum::FLOAT : TokenKindEnum::INT,
+//            $start,
+//            $pos,
+//            $line,
+//            $col,
+//            $prev,
+//            sliceString($body, $start, $pos)
+//        );
+//    }
+//
+//    /**
+//     * @param string $body
+//     * @param int    $bodyLength
+//     * @param int    $pos
+//     * @param int    $line
+//     * @param int    $col
+//     * @param Token  $prev
+//     * @return Token
+//     * @throws SyntaxErrorException
+//     */
+//    protected function readString(string $body, int $bodyLength, int $pos, int $line, int $col, Token $prev): Token
+//    {
+//        $start      = $pos;
+//        $pos        = $start + 1;
+//        $chunkStart = $pos;
+//        $value      = '';
+//
+//        while ($pos < $bodyLength && ($code = charCodeAt($body, $pos)) !== null && !isLineTerminator($code)) {
+//            // Closing Quote (")
+//            if ($code === 34) {
+//                $value .= sliceString($body, $chunkStart, $pos);
+//                return new Token(TokenKindEnum::STRING, $start, $pos + 1, $line, $col, $prev, $value);
+//            }
+//
+//            if (isSourceCharacter($code)) {
+//                throw new SyntaxErrorException(
+//                    $this->lexer->getSource(),
+//                    $pos,
+//                    \sprintf('Invalid character within String: %s.', printCharCode($code))
+//                );
+//            }
+//
+//            ++$pos;
+//
+//            if ($code === 92) {
+//                // \
+//                $value .= sliceString($body, $chunkStart, $pos - 1);
+//                $code  = charCodeAt($body, $pos);
+//
+//                switch ($code) {
+//                    case 34:
+//                        $value .= '"';
+//                        break;
+//                    case 47:
+//                        $value .= '/';
+//                        break;
+//                    case 92:
+//                        $value .= '\\';
+//                        break;
+//                    case 98:
+//                        $value .= '\b';
+//                        break;
+//                    case 102:
+//                        $value .= '\f';
+//                        break;
+//                    case 110:
+//                        $value .= '\n';
+//                        break;
+//                    case 114:
+//                        $value .= '\r';
+//                        break;
+//                    case 116:
+//                        $value .= '\t';
+//                        break;
+//                    case 117:
+//                        // u
+//                        $unicodeString = sliceString($body, $pos + 1, $pos + 5);
+//
+//                        if (!\preg_match('/[0-9A-Fa-f]{4}/', $unicodeString)) {
+//                            throw new SyntaxErrorException(
+//                                $this->lexer->getSource(),
+//                                $pos,
+//                                \sprintf('Invalid character escape sequence: \\u%s.', $unicodeString)
+//                            );
+//                        }
+//
+//                        $value .= '\\u' . $unicodeString;
+//                        $pos   += 4;
+//                        break;
+//                    default:
+//                        throw new SyntaxErrorException(
+//                            $this->lexer->getSource(),
+//                            $pos,
+//                            \sprintf('Invalid character escape sequence: \\%s.', \chr($code))
+//                        );
+//                }
+//
+//                ++$pos;
+//
+//                $chunkStart = $pos;
+//            }
+//        }
+//
+//        throw new SyntaxErrorException($this->lexer->getSource(), $pos, 'Unterminated string.');
+//    }
+//
+//    /**
+//     * @param int   $pos
+//     * @param int   $line
+//     * @param int   $col
+//     * @param Token $prev
+//     * @return Token
+//     */
+//    protected function readComment(int $pos, int $line, int $col, Token $prev): Token
+//    {
+//        $body  = $this->lexer->getBody();
+//        $start = $pos;
+//
+//        do {
+//            $code = charCodeAt($body, ++$pos);
+//        } while ($code !== null && ($code > 0x001f || $code === 0x0009)); // SourceCharacter but not LineTerminator
+//
+//        return new Token(
+//            TokenKindEnum::COMMENT,
+//            $start,
+//            $pos,
+//            $line,
+//            $col,
+//            $prev,
+//            sliceString($body, $start + 1, $pos)
+//        );
+//    }
+//
+//    /**
+//     * @param int $code
+//     * @param int $pos
+//     * @return int
+//     * @throws SyntaxErrorException
+//     */
+//    protected function readDigits(int $code, int $pos): int
+//    {
+//        $body = $this->lexer->getBody();
+//
+//        if (isNumber($code)) {
+//            do {
+//                $code = charCodeAt($body, ++$pos);
+//            } while (isNumber($code));
+//
+//            return $pos;
+//        }
+//
+//        throw new SyntaxErrorException(
+//            $this->lexer->getSource(),
+//            $pos,
+//            sprintf('Invalid number, expected digit but got: %s.', printCharCode($code))
+//        );
+//    }
 }

--- a/src/Language/TokenReaderInterface.php
+++ b/src/Language/TokenReaderInterface.php
@@ -7,15 +7,13 @@ interface TokenReaderInterface
 
     /**
      * @param string $body
-     * @param int    $bodyLength
-     * @param int    $code
      * @param int    $pos
      * @param int    $line
      * @param int    $col
      * @param Token  $prev
      * @return Token|null
      */
-    public function read(string $body, int $bodyLength, int $code, int $pos, int $line, int $col, Token $prev): ?Token;
+    public function read(string $body, int $pos, int $line, int $col, Token $prev): ?Token;
 
     /**
      * @param LexerInterface $lexer

--- a/src/Language/TokenReaderInterface.php
+++ b/src/Language/TokenReaderInterface.php
@@ -6,20 +6,16 @@ interface TokenReaderInterface
 {
 
     /**
-     * @param int $code
-     * @param int $pos
-     * @param int $line
-     * @param int $col
-     * @param Token $prev
-     * @return Token
+     * @param string $body
+     * @param int    $bodyLength
+     * @param int    $code
+     * @param int    $pos
+     * @param int    $line
+     * @param int    $col
+     * @param Token  $prev
+     * @return Token|null
      */
-    public function read(
-      int $code,
-      int $pos,
-      int $line,
-      int $col,
-      Token $prev
-    ): Token;
+    public function read(string $body, int $bodyLength, int $code, int $pos, int $line, int $col, Token $prev): ?Token;
 
     /**
      * @param LexerInterface $lexer

--- a/src/Language/utils.php
+++ b/src/Language/utils.php
@@ -3,10 +3,14 @@
 namespace Digia\GraphQL\Language;
 
 /**
+ * Multi-byte compatible `chr`.
+ *
+ * Based on the Symfony's Mbstring polyfills.
+ *
  * @param int $code
  * @return string
  */
-function unicodeChr(int $code)
+function mbChr(int $code)
 {
     if (0x80 > $code %= 0x200000) {
         return \chr($code);
@@ -22,11 +26,15 @@ function unicodeChr(int $code)
 }
 
 /**
+ * Multi-byte compatible `ord`.
+ *
+ * Based on the Symfony's Mbstring polyfills.
+ *
  * @param string $string
  * @param string $encoding
  * @return int
  */
-function unicodeOrd(string $s)
+function mbOrd(string $s)
 {
     /** @noinspection CallableParameterUseCaseInTypeContextInspection */
     $code = ($s = \unpack('C*', \substr($s, 0, 4))) ? $s[1] : 0;
@@ -51,7 +59,7 @@ function unicodeOrd(string $s)
  */
 function charCodeAt(string $string, int $position): int
 {
-    return unicodeOrd(\mb_substr($string, $position, 1, 'UTF-8'));
+    return mbOrd(\mb_substr($string, $position, 1, 'UTF-8'));
 }
 
 /**
@@ -66,7 +74,7 @@ function printCharCode(int $code): string
 
     return $code < 0x007F
         // Trust JSON for ASCII.
-        ? \json_encode(unicodeChr($code))
+        ? \json_encode(mbChr($code))
         // Otherwise print the escaped form.
         : '"\\u' . \dechex($code) . '"';
 }
@@ -204,10 +212,10 @@ function isEscapedTripleQuote(
  */
 function uniCharCode(string $a, string $b, string $c, string $d): string
 {
-    return (\dechex(unicodeOrd($a)) << 12) |
-        (\dechex(unicodeOrd($b)) << 8) |
-        (\dechex(unicodeOrd($c)) << 4) |
-        \dechex(unicodeOrd($d));
+    return (\dechex(mbOrd($a)) << 12) |
+        (\dechex(mbOrd($b)) << 8) |
+        (\dechex(mbOrd($c)) << 4) |
+        \dechex(mbOrd($d));
 }
 
 /**

--- a/src/Language/utils.php
+++ b/src/Language/utils.php
@@ -196,26 +196,7 @@ function isEscapedTripleQuote(
     return $code === 92 &&
         charCodeAt($body, $pos + 1) === 34 &&
         charCodeAt($body, $pos + 2) === 34 &&
-        charCodeAt($body, $pos + 3) === 34;
-}
-
-/**
- * Converts four hexidecimal chars to the integer that the
- * string represents. For example, uniCharCode('0','0','0','f')
- * will return 15, and uniCharCode('0','0','f','f') returns 255.
- *
- * @param string $a
- * @param string $b
- * @param string $c
- * @param string $d
- * @return string
- */
-function uniCharCode(string $a, string $b, string $c, string $d): string
-{
-    return (\dechex(mbOrd($a)) << 12) |
-        (\dechex(mbOrd($b)) << 8) |
-        (\dechex(mbOrd($c)) << 4) |
-        \dechex(mbOrd($d));
+        charCodeAt($body, $pos + 3) === 34; // \"""
 }
 
 /**
@@ -224,8 +205,7 @@ function uniCharCode(string $a, string $b, string $c, string $d): string
  */
 function isOperation(string $value): bool
 {
-    // TODO: Benchmark
-    return \in_array($value, ['query', 'mutation', 'subscription'], true);
+    return $value === 'query' || $value === 'mutation' || $value === 'subscription';
 }
 
 /**

--- a/src/Language/utils.php
+++ b/src/Language/utils.php
@@ -29,7 +29,7 @@ function ordUTF8(string $string)
  */
 function charCodeAt(string $string, int $position): int
 {
-    return ordUTF8($string[$position]);
+    return ordUTF8(mb_substr($string, $position, 1));
 }
 
 /**

--- a/src/Language/utils.php
+++ b/src/Language/utils.php
@@ -40,7 +40,7 @@ function charCodeAt(string $string, int $position, bool $convertEncoding = false
  */
 function printCharCode(int $code): string
 {
-    if ($code === null) {
+    if ($code === 0x0000) {
         return '<EOF>';
     }
     return $code < 0x007F
@@ -77,7 +77,7 @@ function isLetter(int $code): bool
  */
 function isNumber(int $code): bool
 {
-    return $code === 45 || ($code >= 48 && $code <= 57); // - or 0-9
+    return $code >= 48 && $code <= 57; // 0-9
 }
 
 /**
@@ -113,7 +113,7 @@ function isLineTerminator(int $code): bool
  */
 function isSourceCharacter(int $code): bool
 {
-    return $code < 0x0020 && $code !== 0x0009;
+    return $code < 0x0020 && $code !== 0x0009; // any source character EXCEPT HT (Horizontal Tab)
 }
 
 /**

--- a/tests/Functional/Language/ParserTest.php
+++ b/tests/Functional/Language/ParserTest.php
@@ -71,8 +71,6 @@ class ParserTest extends TestCase
           { field(arg: "Has a \u0A0A multi-byte character.") }
         '));
 
-        $this->markTestIncomplete('BUG: Multi-byte characters in strings are not handled correctly.');
-
         $this->assertArraySubset([
             'definitions' => [
                 [
@@ -83,7 +81,6 @@ class ParserTest extends TestCase
                                     [
                                         'value' => [
                                             'kind' => NodeKindEnum::STRING,
-                                            // TODO: Fix this test case.
                                             'value' => 'Has a \u0A0A multi-byte character.',
                                         ],
                                     ],

--- a/tests/Unit/Language/LexerTest.php
+++ b/tests/Unit/Language/LexerTest.php
@@ -17,7 +17,7 @@ class LexerTest extends TestCase
 {
     public function testDisallowsUncommonControlCharacters(): void
     {
-        $this->assertSyntaxError("\u{0007}", 'Cannot contain the invalid character "\u0007"', 1, 1);
+        $this->assertSyntaxError("\u{0007}", 'Cannot contain the invalid character "\u0007".', 1, 1);
     }
 
     public function testBomCharacter(): void
@@ -97,7 +97,7 @@ EOD;
         $this->assertLexerTokenPropertiesEqual('"unicode \\u1234\\u5678\\u90AB\\uCDEF"', TokenKindEnum::STRING, 0, 34,
             'unicode \u1234\u5678\u90AB\uCDEF');
 
-        $this->assertSyntaxError('"', 'Unterminated string.', 1, 1);
+        $this->assertSyntaxError('"', 'Cannot parse the unexpected character "\"".', 1, 1);
     }
 
     public function testBlockStrings(): void
@@ -182,6 +182,7 @@ EOD;
     private function getLexer(string $source): LexerInterface
     {
         $lexer = GraphQL::make(LexerInterface::class);
+        /** @noinspection PhpUnhandledExceptionInspection */
         $lexer->setSource(new Source($source));
 
         return $lexer;

--- a/tests/Unit/Language/LexerTest.php
+++ b/tests/Unit/Language/LexerTest.php
@@ -6,8 +6,11 @@ use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\GraphQL;
 use Digia\GraphQL\Language\LexerInterface;
 use Digia\GraphQL\Language\Source;
+use Digia\GraphQL\Language\SourceLocation;
+use Digia\GraphQL\Language\Token;
 use Digia\GraphQL\Language\TokenKindEnum;
 use Digia\GraphQL\Test\TestCase;
+use function Digia\GraphQL\Language\dedent;
 
 /**
  * Class LexerTest
@@ -19,7 +22,7 @@ class LexerTest extends TestCase
 
     public function testDisallowsUncommonControlCharacters(): void
     {
-        $this->assertSyntaxError("\u{0007}", 'Cannot contain the invalid character "\u0007".', 1, 1);
+        $this->assertSyntaxError("\u{0007}", 'Cannot contain the invalid character "\u0007".', [1, 1]);
     }
 
     // accepts BOM header
@@ -75,7 +78,9 @@ foo#comment
 EOD;
 
         $this->assertLexerTokenPropertiesEqual($whitespaceString, TokenKindEnum::NAME, [5, 8], 'foo');
+
         $this->assertLexerTokenPropertiesEqual($commentedString, TokenKindEnum::NAME, [9, 12], 'foo');
+
         $this->assertLexerTokenPropertiesEqual(',,,foo,,,', TokenKindEnum::NAME, [3, 6], 'foo');
     }
 
@@ -97,55 +102,159 @@ EOD;
         }
     }
 
-    // TODO: updates line numbers in error for file context
+    // updates line numbers in error for file context
 
-    // TODO: updates column numbers in error for file context
+    public function testUpdatesLineNumbersInErrorForFileContext()
+    {
+        $caughtError = null;
+
+        try {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $source = new Source("\n\n     ?\n\n", 'foo.php', new SourceLocation(11, 12));
+            $this->getLexer($source)->advance();
+        } catch (SyntaxErrorException $e) {
+            $caughtError = $e;
+        }
+
+        $this->assertEquals(
+            "Syntax Error: Cannot parse the unexpected character \"?\".\n" .
+            "\n" .
+            "foo.php (13:6)\n" .
+            "12: \n" .
+            "13:      ?\n" .
+            "         ^\n" .
+            "14: \n",
+            (string)$caughtError
+        );
+    }
+
+    // updates column numbers in error for file context
+
+    public function testUpdatesColumnNumbersInErrorForFileContext()
+    {
+        $caughtError = null;
+
+        try {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $source = new Source('?', 'foo.php', new SourceLocation(1, 5));
+            $this->getLexer($source)->advance();
+        } catch (SyntaxErrorException $e) {
+            $caughtError = $e;
+        }
+
+        $this->assertEquals(
+            "Syntax Error: Cannot parse the unexpected character \"?\".\n" .
+            "\n" .
+            "foo.php (1:5)\n" .
+            "1:     ?\n" .
+            "       ^\n",
+            (string)$caughtError
+        );
+    }
 
     // lexes strings
 
     public function testLexesStrings(): void
     {
-        $this->assertLexerTokenPropertiesEqual(
-            '"simple"',
-            TokenKindEnum::STRING,
-            [0, 8],
-            'simple'
-        );
-        $this->assertLexerTokenPropertiesEqual(
-            '" white space "',
-            TokenKindEnum::STRING,
-            [0, 15],
-            ' white space '
-        );
-        $this->assertLexerTokenPropertiesEqual(
-            '"quote \\""',
-            TokenKindEnum::STRING,
-            [0, 10],
-            'quote "'
-        );
+        $this->assertLexerTokenPropertiesEqual('"simple"', TokenKindEnum::STRING, [0, 8], 'simple');
+
+        $this->assertLexerTokenPropertiesEqual('" white space "', TokenKindEnum::STRING, [0, 15], ' white space ');
+
+        $this->assertLexerTokenPropertiesEqual('"quote \\""', TokenKindEnum::STRING, [0, 10], 'quote "');
+
         $this->assertLexerTokenPropertiesEqual(
             '"escaped \\n\\r\\b\\t\\f"',
             TokenKindEnum::STRING,
             [0, 20],
             'escaped \n\r\b\t\f'
         );
-        $this->assertLexerTokenPropertiesEqual(
-            '"slashes \\\\ \\/"',
-            TokenKindEnum::STRING,
-            [0, 15],
-            'slashes \\ /'
-        );
+
+        $this->assertLexerTokenPropertiesEqual('"slashes \\\\ \\/"', TokenKindEnum::STRING, [0, 15], 'slashes \\ /');
+
         $this->assertLexerTokenPropertiesEqual(
             '"unicode \\u1234\\u5678\\u90AB\\uCDEF"',
             TokenKindEnum::STRING,
             [0, 34],
             'unicode \u1234\u5678\u90AB\uCDEF'
         );
-
-        $this->assertSyntaxError('"', 'Cannot parse the unexpected character "\"".', 1, 1);
     }
 
-    // TODO: lex reports useful string errors
+    // lex reports useful string errors
+
+    public function testLexReportsUsefulStringErrors()
+    {
+        $this->assertSyntaxError('"', 'Unterminated string.', [1, 2]);
+
+        $this->assertSyntaxError('"no end quote', 'Unterminated string.', [1, 14]);
+
+        $this->assertSyntaxError(
+            "'single quotes'",
+            'Unexpected single quote character (\'), did you mean to use a double quote (")?',
+            [1, 1]
+        );
+
+        // TODO: Fix the following unicode-related tests
+
+//        $this->assertSyntaxError(
+//            '"contains unescaped \u0007 control char"',
+//            'Invalid character within String: "\\u0007".',
+//            [1, 21]
+//        );
+//
+//        $this->assertSyntaxError(
+//            '"null-byte is not \u0000 end of file"',
+//            'Invalid character within String: "\\u0000".',
+//            [1, 19]
+//        );
+//
+//        $this->assertSyntaxError('"multi\nline"', 'Unterminated string', [1, 7]);
+//
+//        $this->assertSyntaxError('"multi\rline"', 'Unterminated string', [1, 7]);
+
+        $this->assertSyntaxError(
+            '"bad \\z esc"',
+            'Invalid character escape sequence: \\z.',
+            [1, 7]
+        );
+
+        $this->assertSyntaxError(
+            '"bad \\x esc"',
+            'Invalid character escape sequence: \\x.',
+            [1, 7]
+        );
+
+        // TODO: Fix the following unicode-related tests
+
+//        $this->assertSyntaxError(
+//            '"bad \\u1 esc"',
+//            'Invalid character escape sequence: \\u1 es.',
+//            [1, 7]
+//        );
+//
+//        $this->assertSyntaxError(
+//            '"bad \\u0XX1 esc"',
+//            'Invalid character escape sequence: \\u0XX1.',
+//            [1, 7]
+//        );
+//
+//        $this->assertSyntaxError(
+//            '"bad \\uXXXX esc"',
+//            'Invalid character escape sequence: \\uXXXX.',
+//            [1, 7]
+//        );
+//
+//        $this->assertSyntaxError(
+//            '"bad \\uFXXX esc"',
+//            'Invalid character escape sequence: \\uFXXX.',
+//            [1, 7]
+//        );
+//
+//        $this->assertSyntaxError(
+//            '"bad \\uXXXF esc"',
+//            'Invalid character escape sequence: \\uXXXF.',
+//            [1, 7]
+//        );
+    }
 
     // lexes block strings
 
@@ -157,6 +266,7 @@ EOD;
             [0, 12],
             'simple'
         );
+
         $this->assertLexerTokenPropertiesEqual(
             '""" white space """',
             TokenKindEnum::BLOCK_STRING,
@@ -169,30 +279,35 @@ EOD;
             [0, 22],
             'contains " quote'
         );
+
         $this->assertLexerTokenPropertiesEqual(
             '"""contains \\""" triplequote"""',
             TokenKindEnum::BLOCK_STRING,
             [0, 31],
             'contains """ triplequote'
         );
+
         $this->assertLexerTokenPropertiesEqual(
             '"""' . "multi\nline" . '""""',
             TokenKindEnum::BLOCK_STRING,
             [0, 16],
             "multi\nline"
         );
+
         $this->assertLexerTokenPropertiesEqual(
             '"""' . "multi\rline\r\nnormalized" . '""""',
             TokenKindEnum::BLOCK_STRING,
             [0, 28],
             "multi\nline\nnormalized"
         );
+
         $this->assertLexerTokenPropertiesEqual(
             '"""' . "unescaped \\n\\r\\b\\t\\f\\u1234" . '""""',
             TokenKindEnum::BLOCK_STRING,
             [0, 32],
             'unescaped \\n\\r\\b\\t\\f\\u1234'
         );
+
         $this->assertLexerTokenPropertiesEqual(
             '"""' . "slashes \\\\ \\/" . '""""',
             TokenKindEnum::BLOCK_STRING,
@@ -200,21 +315,205 @@ EOD;
             "slashes \\\\ \\/"
         );
 
-        $multiline = <<<EOD
-"""
-
-spans
-multiple
-lines
-    
-"""
-EOD;
-
         $this->assertLexerTokenPropertiesEqual(
-            $multiline,
+            dedent('
+            """
+            
+            spans
+              multiple
+                lines
+                
+            """
+            '),
             TokenKindEnum::BLOCK_STRING,
-            [0, 34],
-            "spans\nmultiple\nlines");
+            [0, 40],
+            "spans\n  multiple\n    lines"
+        );
+    }
+
+    // lex reports useful block string errors
+
+    public function testLexReportsUsefulBlockStringErrors()
+    {
+        $this->assertSyntaxError('"""', 'Unterminated string.', [1, 4]);
+
+        $this->assertSyntaxError('"""no end quote', 'Unterminated string.', [1, 16]);
+
+        // TODO: Fix the following unicode-related tests
+
+//        $this->assertSyntaxError(
+//            '"""contains unescaped \u0007 control char"""',
+//            'Invalid character within String: "\\u0007".',
+//            [1, 23]
+//        );
+//
+//        $this->assertSyntaxError(
+//            '"""null-byte is not \u0000 end of file"""',
+//            'Invalid character within String: "\\u0000".',
+//            [1, 21]
+//        );
+    }
+
+    // lexes numbers
+
+    public function testLexesNumbers()
+    {
+        $this->assertLexerTokenPropertiesEqual('4', TokenKindEnum::INT, [0, 1], '4');
+
+        $this->assertLexerTokenPropertiesEqual('4.123', TokenKindEnum::FLOAT, [0, 5], '4.123');
+
+        $this->assertLexerTokenPropertiesEqual('-4', TokenKindEnum::INT, [0, 2], '-4');
+
+        $this->assertLexerTokenPropertiesEqual('9', TokenKindEnum::INT, [0, 1], '9');
+
+        $this->assertLexerTokenPropertiesEqual('0', TokenKindEnum::INT, [0, 1], '0');
+
+        $this->assertLexerTokenPropertiesEqual('-4.123', TokenKindEnum::FLOAT, [0, 6], '-4.123');
+
+        $this->assertLexerTokenPropertiesEqual('0.123', TokenKindEnum::FLOAT, [0, 5], '0.123');
+
+        $this->assertLexerTokenPropertiesEqual('123e4', TokenKindEnum::FLOAT, [0, 5], '123e4');
+
+        $this->assertLexerTokenPropertiesEqual('123E4', TokenKindEnum::FLOAT, [0, 5], '123E4');
+
+        $this->assertLexerTokenPropertiesEqual('123e-4', TokenKindEnum::FLOAT, [0, 6], '123e-4');
+
+        $this->assertLexerTokenPropertiesEqual('123E-4', TokenKindEnum::FLOAT, [0, 6], '123E-4');
+
+        $this->assertLexerTokenPropertiesEqual('123e+4', TokenKindEnum::FLOAT, [0, 6], '123e+4');
+
+        $this->assertLexerTokenPropertiesEqual('-1.123e4', TokenKindEnum::FLOAT, [0, 8], '-1.123e4');
+
+        $this->assertLexerTokenPropertiesEqual('-1.123E4', TokenKindEnum::FLOAT, [0, 8], '-1.123E4');
+
+        $this->assertLexerTokenPropertiesEqual('-1.123e+4', TokenKindEnum::FLOAT, [0, 9], '-1.123e+4');
+
+        $this->assertLexerTokenPropertiesEqual('-1.123e4567', TokenKindEnum::FLOAT, [0, 11], '-1.123e4567');
+    }
+
+    // lex reports useful number errors
+
+    public function testLexReportsUsefulNumberErrors()
+    {
+        $this->assertSyntaxError('00', 'Invalid number, unexpected digit after 0: "0".', [1, 2]);
+
+        $this->assertSyntaxError('+1', 'Cannot parse the unexpected character "+".', [1, 1]);
+
+        $this->assertSyntaxError('1.', 'Invalid number, expected digit but got: <EOF>.', [1, 3]);
+
+        $this->assertSyntaxError('1.e1', 'Invalid number, expected digit but got: "e".', [1, 3]);
+
+        $this->assertSyntaxError('.123', 'Cannot parse the unexpected character ".".', [1, 1]);
+
+        $this->assertSyntaxError('1.A', 'Invalid number, expected digit but got: "A".', [1, 3]);
+
+        $this->assertSyntaxError('-A', 'Invalid number, expected digit but got: "A".', [1, 2]);
+
+        $this->assertSyntaxError('1.0e', 'Invalid number, expected digit but got: <EOF>.', [1, 5]);
+
+        $this->assertSyntaxError('1.0eA', 'Invalid number, expected digit but got: "A".', [1, 5]);
+    }
+
+    // lexes punctuation
+
+    public function testLexesPunctuation()
+    {
+        $this->assertLexerTokenPropertiesEqual('!', TokenKindEnum::BANG, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('$', TokenKindEnum::DOLLAR, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('(', TokenKindEnum::PAREN_L, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual(')', TokenKindEnum::PAREN_R, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('...', TokenKindEnum::SPREAD, [0, 3], null);
+        $this->assertLexerTokenPropertiesEqual(':', TokenKindEnum::COLON, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('=', TokenKindEnum::EQUALS, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('@', TokenKindEnum::AT, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('[', TokenKindEnum::BRACKET_L, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual(']', TokenKindEnum::BRACKET_R, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('{', TokenKindEnum::BRACE_L, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('|', TokenKindEnum::PIPE, [0, 1], null);
+        $this->assertLexerTokenPropertiesEqual('}', TokenKindEnum::BRACE_R, [0, 1], null);
+    }
+
+    // lex reports useful unknown character error
+
+    public function testLexReportsUsefulUnknownCharacterError()
+    {
+        $this->assertSyntaxError('..', 'Cannot parse the unexpected character ".".', [1, 1]);
+
+        $this->assertSyntaxError('?', 'Cannot parse the unexpected character "?".', [1, 1]);
+
+        // TODO: Fix the following unicode-related tests
+
+//        $this->assertSyntaxError('\u203B', 'Cannot parse the unexpected character "\\u203B".', [1, 1]);
+//
+//        $this->assertSyntaxError('\u200b', 'Cannot parse the unexpected character "\\u200B".', [1, 1]);
+    }
+
+    // lex reports useful information for dashes in names
+
+    public function testLexReportsUsefulInformationForDashesInNames()
+    {
+        $lexer      = $this->getLexer('a-b');
+        $firstToken = $lexer->advance();
+
+        $this->assertTokenPropertiesEqual($firstToken, TokenKindEnum::NAME, [0, 1], 'a');
+
+        $caughtError = null;
+
+        try {
+            $lexer->advance();
+        } catch (SyntaxErrorException $e) {
+            $caughtError = $e;
+        }
+
+        $this->assertEquals('Syntax Error: Invalid number, expected digit but got: "b".', $caughtError->getMessage());
+        $this->assertEquals([['line' => 1, 'column' => 3]], $caughtError->getLocationsAsArray());
+    }
+
+    // produces double linked list of tokens, including comments
+
+    public function testProducesDoubleLinkedListOfTokensIncludingComments()
+    {
+        $lexer = $this->getLexer(dedent('
+        {
+          #comment
+          field
+        }
+        '));
+
+        $startToken = $lexer->getToken();
+        $endToken   = null;
+
+        do {
+            $endToken = $lexer->advance();
+            // Lexer advances over ignored comment tokens to make writing parsers
+            // easier, but will include them in the linked list result.
+            $this->assertNotEquals(TokenKindEnum::COMMENT, $endToken->getKind());
+        } while ($endToken->getKind() !== TokenKindEnum::EOF);
+
+        $this->assertNull($startToken->getPrev());
+        $this->assertNull($endToken->getNext());
+
+        $tokens = [];
+
+        for ($token = $startToken; null !== $token; $token = $token->getNext()) {
+            if (!empty($tokens)) {
+                // Tokens are double-linked, prev should point to last seen token.
+                $this->assertEquals($tokens[\count($tokens) - 1], $token->getPrev());
+            }
+
+            $tokens[] = $token;
+        }
+
+        $this->assertEquals([
+            '<SOF>',
+            '{',
+            'Comment',
+            'Name',
+            '}',
+            '<EOF>',
+        ], \array_map(function (Token $token) {
+            return $token->getKind();
+        }, $tokens));
     }
 
     /**
@@ -223,7 +522,7 @@ EOD;
      * @param int    $line
      * @param int    $column
      */
-    private function assertSyntaxError(string $source, string $expectedExceptionMessage, int $line, int $column): void
+    private function assertSyntaxError(string $source, string $expectedExceptionMessage, array $position): void
     {
         try {
             $this->getLexer($source)->advance();
@@ -231,21 +530,31 @@ EOD;
             $this->fail('Expected an exception to be thrown');
         } catch (SyntaxErrorException $e) {
             $this->assertEquals('Syntax Error: ' . $expectedExceptionMessage, $e->getMessage());
-            $this->assertEquals([['line' => $line, 'column' => $column]], $e->getLocationsAsArray());
+            $this->assertEquals([['line' => $position[0], 'column' => $position[1]]], $e->getLocationsAsArray());
         }
     }
 
     /**
      * @param string $source
      * @param string $kind
-     * @param int    $start
-     * @param int    $end
+     * @param array  $location
      * @param mixed  $value
      */
     private function assertLexerTokenPropertiesEqual(string $source, string $kind, array $location, $value): void
     {
         $token = $this->getLexer($source)->advance();
 
+        $this->assertTokenPropertiesEqual($token, $kind, $location, $value);
+    }
+
+    /**
+     * @param Token  $token
+     * @param string $kind
+     * @param array  $location
+     * @param mixed  $value
+     */
+    private function assertTokenPropertiesEqual(Token $token, string $kind, array $location, $value): void
+    {
         $this->assertEquals($kind, $token->getKind());
         $this->assertEquals($location[0], $token->getStart());
         $this->assertEquals($location[1], $token->getEnd());
@@ -253,15 +562,15 @@ EOD;
     }
 
     /**
-     * @param string $source
+     * @param Source|string $source
      * @return LexerInterface
      */
-    private function getLexer(string $source): LexerInterface
+    private function getLexer($source): LexerInterface
     {
         $lexer = GraphQL::make(LexerInterface::class);
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $lexer->setSource(new Source($source));
+        $lexer->setSource($source instanceof Source ? $source : new Source($source));
 
         return $lexer;
     }

--- a/tests/Unit/Language/LexerTest.php
+++ b/tests/Unit/Language/LexerTest.php
@@ -193,67 +193,65 @@ EOD;
             [1, 1]
         );
 
-        // TODO: Fix the following unicode-related tests
+        $this->assertSyntaxError(
+            "\"contains unescaped \u{0007} control char\"",
+            'Invalid character within String: "\\u0007".',
+            [1, 21]
+        );
+
+        // TODO: Fix the following EOF-related test
 
 //        $this->assertSyntaxError(
-//            '"contains unescaped \u0007 control char"',
-//            'Invalid character within String: "\\u0007".',
-//            [1, 21]
-//        );
-//
-//        $this->assertSyntaxError(
-//            '"null-byte is not \u0000 end of file"',
+//            "\"null-byte is not \u{0000} end of file\"",
 //            'Invalid character within String: "\\u0000".',
 //            [1, 19]
 //        );
-//
-//        $this->assertSyntaxError('"multi\nline"', 'Unterminated string', [1, 7]);
-//
-//        $this->assertSyntaxError('"multi\rline"', 'Unterminated string', [1, 7]);
+
+        $this->assertSyntaxError("\"multi\nline\"", 'Unterminated string.', [1, 7]);
+
+        $this->assertSyntaxError("\"multi\rline\"", 'Unterminated string.', [1, 7]);
 
         $this->assertSyntaxError(
-            '"bad \\z esc"',
+            "\"bad \\z esc\"",
             'Invalid character escape sequence: \\z.',
             [1, 7]
         );
 
         $this->assertSyntaxError(
-            '"bad \\x esc"',
+            "\"bad \\x esc\"",
             'Invalid character escape sequence: \\x.',
             [1, 7]
         );
 
-        // TODO: Fix the following unicode-related tests
+        $this->assertSyntaxError(
+            "\"bad \\u1 esc\"",
+            'Invalid character escape sequence: \\u1 es.',
+            [1, 7]
+        );
 
-//        $this->assertSyntaxError(
-//            '"bad \\u1 esc"',
-//            'Invalid character escape sequence: \\u1 es.',
-//            [1, 7]
-//        );
-//
-//        $this->assertSyntaxError(
-//            '"bad \\u0XX1 esc"',
-//            'Invalid character escape sequence: \\u0XX1.',
-//            [1, 7]
-//        );
-//
-//        $this->assertSyntaxError(
-//            '"bad \\uXXXX esc"',
-//            'Invalid character escape sequence: \\uXXXX.',
-//            [1, 7]
-//        );
-//
-//        $this->assertSyntaxError(
-//            '"bad \\uFXXX esc"',
-//            'Invalid character escape sequence: \\uFXXX.',
-//            [1, 7]
-//        );
-//
-//        $this->assertSyntaxError(
-//            '"bad \\uXXXF esc"',
-//            'Invalid character escape sequence: \\uXXXF.',
-//            [1, 7]
-//        );
+        $this->assertSyntaxError(
+            "\"bad \\u0XX1 esc\"",
+            'Invalid character escape sequence: \\u0XX1.',
+            [1, 7]
+        );
+
+        $this->assertSyntaxError(
+            "\"bad \\uXXXX esc\"",
+            'Invalid character escape sequence: \\uXXXX.',
+            [1, 7]
+        );
+
+        $this->assertSyntaxError(
+            "\"bad \\uFXXX esc\"",
+            'Invalid character escape sequence: \\uFXXX.',
+            [1, 7]
+        );
+
+        $this->assertSyntaxError(
+            "\"bad \\uXXXF esc\"",
+            'Invalid character escape sequence: \\uXXXF.',
+            [1, 7]
+        );
     }
 
     // lexes block strings
@@ -339,16 +337,16 @@ EOD;
 
         $this->assertSyntaxError('"""no end quote', 'Unterminated string.', [1, 16]);
 
-        // TODO: Fix the following unicode-related tests
+        $this->assertSyntaxError(
+            "\"\"\"contains unescaped \u{0007} control char\"\"\"",
+            'Invalid character within String: "\\u0007".',
+            [1, 23]
+        );
+
+        // TODO: Fix the following EOF-related test
 
 //        $this->assertSyntaxError(
-//            '"""contains unescaped \u0007 control char"""',
-//            'Invalid character within String: "\\u0007".',
-//            [1, 23]
-//        );
-//
-//        $this->assertSyntaxError(
-//            '"""null-byte is not \u0000 end of file"""',
+//            "\"\"\"null-byte is not \u{0000} end of file\"\"\"",
 //            'Invalid character within String: "\\u0000".',
 //            [1, 21]
 //        );
@@ -441,11 +439,9 @@ EOD;
 
         $this->assertSyntaxError('?', 'Cannot parse the unexpected character "?".', [1, 1]);
 
-        // TODO: Fix the following unicode-related tests
+        $this->assertSyntaxError("\u{203B}", 'Cannot parse the unexpected character "\\u203b".', [1, 1]);
 
-//        $this->assertSyntaxError('\u203B', 'Cannot parse the unexpected character "\\u203B".', [1, 1]);
-//
-//        $this->assertSyntaxError('\u200b', 'Cannot parse the unexpected character "\\u200B".', [1, 1]);
+        $this->assertSyntaxError("\u{200b}", 'Cannot parse the unexpected character "\\u200b".', [1, 1]);
     }
 
     // lex reports useful information for dashes in names

--- a/tests/Unit/Language/LexerTest.php
+++ b/tests/Unit/Language/LexerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Digia\GraphQL\Test\Unit\Language;
+
+use Digia\GraphQL\Error\SyntaxErrorException;
+use Digia\GraphQL\GraphQL;
+use Digia\GraphQL\Language\LexerInterface;
+use Digia\GraphQL\Language\Source;
+use Digia\GraphQL\Language\TokenKindEnum;
+use Digia\GraphQL\Test\TestCase;
+
+/**
+ * Class LexerTest
+ * @package Digia\GraphQL\Test\Unit\Language
+ */
+class LexerTest extends TestCase
+{
+    public function testDisallowsUncommonControlCharacters(): void
+    {
+        $this->assertSyntaxError("\u{0007}", 'Cannot contain the invalid character "\u0007"', 1, 1);
+    }
+
+    public function testBomCharacter(): void
+    {
+        $this->assertLexerTokenPropertiesEqual("\u{FEFF} foo", TokenKindEnum::NAME, 2, 5, 'foo');
+    }
+
+    public function testRecordsLineAndNumber(): void
+    {
+        $token = $this->getLexer("\n \r\n \r  foo\n")->advance();
+
+        $this->assertEquals(TokenKindEnum::NAME, $token->getKind());
+        $this->assertEquals(8, $token->getStart());
+        $this->assertEquals(11, $token->getEnd());
+        $this->assertEquals(4, $token->getLine());
+        $this->assertEquals(3, $token->getColumn());
+        $this->assertEquals('foo', $token->getValue());
+    }
+
+    public function testCanBeJsonSerialized(): void
+    {
+        $token = $this->getLexer('foo')->advance();
+
+        $this->assertJsonStringEqualsJsonString(\json_encode([
+            'kind'   => 'Name',
+            'value'  => 'foo',
+            'line'   => 1,
+            'column' => 1,
+        ]), $token->toJSON());
+    }
+
+    public function testSkipsWhitespaceAndComments(): void
+    {
+        $whitespaceString = <<<EOD
+
+    foo
+    
+    
+    
+EOD;
+
+        $commentedString = <<<EOD
+#comment
+foo#comment
+EOD;
+
+        $this->assertLexerTokenPropertiesEqual($whitespaceString, TokenKindEnum::NAME, 5, 8, 'foo');
+        $this->assertLexerTokenPropertiesEqual($commentedString, TokenKindEnum::NAME, 9, 12, 'foo');
+        $this->assertLexerTokenPropertiesEqual(',,,foo,,,', TokenKindEnum::NAME, 3, 6, 'foo');
+    }
+
+    public function testErrorsRespectWhitespace(): void
+    {
+        $whitespaceErrorString = <<<EOD
+
+
+    ?
+
+EOD;
+
+        try {
+            $this->getLexer($whitespaceErrorString)->advance();
+        } catch (SyntaxErrorException $e) {
+            $this->assertEquals([['line' => 3, 'column' => 5]], $e->getLocationsAsArray());
+        }
+    }
+
+    public function testStrings(): void
+    {
+        $this->assertLexerTokenPropertiesEqual('"simple"', TokenKindEnum::STRING, 0, 8, 'simple');
+        $this->assertLexerTokenPropertiesEqual('" white space "', TokenKindEnum::STRING, 0, 15, ' white space ');
+        $this->assertLexerTokenPropertiesEqual('"quote \\""', TokenKindEnum::STRING, 0, 10, 'quote "');
+        $this->assertLexerTokenPropertiesEqual('"escaped \\n\\r\\b\\t\\f"', TokenKindEnum::STRING, 0, 20,
+            'escaped \n\r\b\t\f');
+        $this->assertLexerTokenPropertiesEqual('"slashes \\\\ \\/"', TokenKindEnum::STRING, 0, 15,
+            'slashes \\ /');
+        $this->assertLexerTokenPropertiesEqual('"unicode \\u1234\\u5678\\u90AB\\uCDEF"', TokenKindEnum::STRING, 0, 34,
+            'unicode \u1234\u5678\u90AB\uCDEF');
+
+        $this->assertSyntaxError('"', 'Unterminated string.', 1, 1);
+    }
+
+    public function testBlockStrings(): void
+    {
+        $this->assertLexerTokenPropertiesEqual('"""simple"""', TokenKindEnum::BLOCK_STRING, 0, 12, 'simple');
+        $this->assertLexerTokenPropertiesEqual('""" white space """', TokenKindEnum::BLOCK_STRING, 0, 19,
+            ' white space ');
+        $this->assertLexerTokenPropertiesEqual('"""contains " quote"""', TokenKindEnum::BLOCK_STRING, 0, 22,
+            'contains " quote');
+        $this->assertLexerTokenPropertiesEqual('"""contains \\""" triplequote"""', TokenKindEnum::BLOCK_STRING, 0, 31,
+            'contains """ triplequote');
+        $this->assertLexerTokenPropertiesEqual('"""' . "multi\nline" . '""""', TokenKindEnum::BLOCK_STRING, 0, 16,
+            "multi\nline");
+        $this->assertLexerTokenPropertiesEqual('"""' . "multi\rline\r\nnormalized" . '""""',
+            TokenKindEnum::BLOCK_STRING,
+            0, 28,
+            "multi\nline\nnormalized");
+        $this->assertLexerTokenPropertiesEqual('"""' . "unescaped \\n\\r\\b\\t\\f\\u1234" . '""""',
+            TokenKindEnum::BLOCK_STRING,
+            0, 32,
+            'unescaped \\n\\r\\b\\t\\f\\u1234');
+        $this->assertLexerTokenPropertiesEqual('"""' . "slashes \\\\ \\/" . '""""',
+            TokenKindEnum::BLOCK_STRING,
+            0, 19,
+            "slashes \\\\ \\/");
+
+        $multiline = <<<EOD
+"""
+
+spans
+multiple
+lines
+    
+"""
+EOD;
+
+        $this->assertLexerTokenPropertiesEqual($multiline,
+            TokenKindEnum::BLOCK_STRING,
+            0, 34,
+            "spans\nmultiple\nlines");
+    }
+
+    /**
+     * @param string $source
+     * @param string $expectedExceptionMessage
+     * @param int    $line
+     * @param int    $column
+     */
+    private function assertSyntaxError(string $source, string $expectedExceptionMessage, int $line, int $column): void
+    {
+        try {
+            $this->getLexer($source)->advance();
+
+            $this->fail('Expected an exception to be thrown');
+        } catch (SyntaxErrorException $e) {
+            $this->assertEquals('Syntax Error: ' . $expectedExceptionMessage, $e->getMessage());
+            $this->assertEquals([['line' => $line, 'column' => $column]], $e->getLocationsAsArray());
+        }
+    }
+
+    /**
+     * @param string $source
+     * @param string $kind
+     * @param int    $start
+     * @param int    $end
+     * @param mixed  $value
+     */
+    private function assertLexerTokenPropertiesEqual(string $source, string $kind, int $start, int $end, $value): void
+    {
+        $token = $this->getLexer($source)->advance();
+
+        $this->assertEquals($kind, $token->getKind());
+        $this->assertEquals($start, $token->getStart());
+        $this->assertEquals($end, $token->getEnd());
+        $this->assertEquals($value, $token->getValue());
+    }
+
+    /**
+     * @param string $source
+     * @return LexerInterface
+     */
+    private function getLexer(string $source): LexerInterface
+    {
+        $lexer = GraphQL::make(LexerInterface::class);
+        $lexer->setSource(new Source($source));
+
+        return $lexer;
+    }
+}


### PR DESCRIPTION
Refactored the token reader to use regular expressions instead of character codes. This *should* increase the lexing performance. However, I couldn't get the string related regular expressions to work, so it would be nice if @fubhy or @Jalle19 can take a look and see if you can get it to work. Please also note that this feature is far from done because it's missing almost all error reporting.

Based on the `lexer-unit-tests` branch.