### PR TITLE
Support for custom types and directives when building schema

### DIFF
--- a/src/Schema/Building/SchemaBuilder.php
+++ b/src/Schema/Building/SchemaBuilder.php
@@ -19,20 +19,6 @@ use Psr\SimpleCache\InvalidArgumentException;
 class SchemaBuilder implements SchemaBuilderInterface
 {
     /**
-     * @var CacheInterface
-     */
-    protected $cache;
-
-    /**
-     * BuilderContextCreator constructor.
-     * @param CacheInterface $cache
-     */
-    public function __construct(CacheInterface $cache)
-    {
-        $this->cache = $cache;
-    }
-
-    /**
      * @inheritdoc
      */
     public function build(
@@ -73,8 +59,7 @@ class SchemaBuilder implements SchemaBuilderInterface
             $resolverRegistry,
             $options['types'] ?? [],
             $options['directives'] ?? [],
-            null, // use the default resolveType-function
-            $this->cache
+            null // use the default resolveType-function
         );
 
         return new BuildingContext($resolverRegistry, $definitionBuilder, $info);

--- a/src/Schema/Building/SchemaBuilderInterface.php
+++ b/src/Schema/Building/SchemaBuilderInterface.php
@@ -19,14 +19,4 @@ interface SchemaBuilderInterface
         ResolverRegistryInterface $resolverRegistry,
         array $options = []
     ): Schema;
-
-    /**
-     * @param DocumentNode              $document
-     * @param ResolverRegistryInterface $resolverRegistry
-     * @return BuildingContextInterface
-     */
-    public function createContext(
-        DocumentNode $document,
-        ResolverRegistryInterface $resolverRegistry
-    ): BuildingContextInterface;
 }

--- a/src/Schema/Building/SchemaBuildingProvider.php
+++ b/src/Schema/Building/SchemaBuildingProvider.php
@@ -19,7 +19,6 @@ class SchemaBuildingProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->container->add(SchemaBuilderInterface::class, SchemaBuilder::class)
-            ->withArgument(CacheInterface::class);
+        $this->container->add(SchemaBuilderInterface::class, SchemaBuilder::class);
     }
 }

--- a/src/Schema/DefinitionBuilder.php
+++ b/src/Schema/DefinitionBuilder.php
@@ -60,6 +60,9 @@ class DefinitionBuilder implements DefinitionBuilderInterface
 
     private const CACHE_PREFIX = 'GraphQL_DefinitionBuilder_';
 
+    private const TYPE_CACHE_SUFFIX      = '_Type';
+    private const DIRECTIVE_CACHE_SUFFIX = '_Directive';
+
     /**
      * @var array
      */
@@ -86,6 +89,8 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     public function __construct(
         array $typeDefinitionsMap,
         ?ResolverRegistryInterface $resolverRegistry = null,
+        array $customTypes = [],
+        array $customDirectives = [],
         ?callable $resolveTypeFunction = null,
         CacheInterface $cache
     ) {
@@ -94,16 +99,8 @@ class DefinitionBuilder implements DefinitionBuilderInterface
         $this->resolveTypeFunction = $resolveTypeFunction ?? [$this, 'defaultTypeResolver'];
         $this->cache               = $cache;
 
-        $builtInTypes = keyMap(
-            \array_merge(specifiedScalarTypes(), introspectionTypes()),
-            function (NamedTypeInterface $type) {
-                return $type->getName();
-            }
-        );
-
-        foreach ($builtInTypes as $name => $type) {
-            $this->setInCache($name, $type);
-        }
+        $this->registerTypes($customTypes);
+        $this->registerDirectives($customDirectives);
     }
 
     /**
@@ -120,23 +117,25 @@ class DefinitionBuilder implements DefinitionBuilderInterface
      * @inheritdoc
      * @param NamedTypeNode|TypeDefinitionNodeInterface $node
      */
-    public function buildType(NodeInterface $node): TypeInterface
+    public function buildType(NodeInterface $node): NamedTypeInterface
     {
         $typeName = $node->getNameValue();
 
-        if (!$this->isInCache($typeName)) {
+        if (!$this->isTypeInCache($typeName)) {
             if ($node instanceof NamedTypeNode) {
                 $definition = $this->getTypeDefinition($typeName);
 
-                $type = null !== $definition ? $this->buildNamedType($definition) : $this->resolveType($node);
+                $type = null !== $definition
+                    ? $this->buildNamedType($definition)
+                    : $this->resolveType($node);
 
-                $this->setInCache($typeName, $type);
+                $this->setTypeInCache($typeName, $type);
             } else {
-                $this->setInCache($typeName, $this->buildNamedType($node));
+                $this->setTypeInCache($typeName, $this->buildNamedType($node));
             }
         }
 
-        return $this->getFromCache($typeName);
+        return $this->getTypeFromCache($typeName);
     }
 
     /**
@@ -144,15 +143,23 @@ class DefinitionBuilder implements DefinitionBuilderInterface
      */
     public function buildDirective(DirectiveDefinitionNode $node): Directive
     {
-        return newDirective([
-            'name'        => $node->getNameValue(),
-            'description' => $node->getDescriptionValue(),
-            'locations'   => \array_map(function (NameNode $node) {
-                return $node->getValue();
-            }, $node->getLocations()),
-            'args'        => $node->hasArguments() ? $this->buildArguments($node->getArguments()) : [],
-            'astNode'     => $node,
-        ]);
+        $directiveName = $node->getNameValue();
+
+        if (!$this->isDirectiveInCache($directiveName)) {
+            $directive = newDirective([
+                'name'        => $node->getNameValue(),
+                'description' => $node->getDescriptionValue(),
+                'locations'   => \array_map(function (NameNode $node) {
+                    return $node->getValue();
+                }, $node->getLocations()),
+                'args'        => $node->hasArguments() ? $this->buildArguments($node->getArguments()) : [],
+                'astNode'     => $node,
+            ]);
+
+            $this->setDirectiveInCache($directiveName, $directive);
+        }
+
+        return $this->getDirectiveFromCache($directiveName);
     }
 
     /**
@@ -179,7 +186,66 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     protected function buildWrappedType(TypeNodeInterface $typeNode): TypeInterface
     {
         $typeDefinition = $this->buildType($this->getNamedTypeNode($typeNode));
-        return buildWrappedType($typeDefinition, $typeNode);
+        return $this->buildWrappedTypeRecursive($typeDefinition, $typeNode);
+    }
+
+    /**
+     * @param TypeInterface      $innerType
+     * @param NamedTypeInterface $inputTypeNode
+     * @return TypeInterface
+     * @throws InvariantException
+     * @throws InvalidTypeException
+     */
+    protected function buildWrappedTypeRecursive(
+        NamedTypeInterface $innerType,
+        TypeNodeInterface $inputTypeNode
+    ): TypeInterface {
+        if ($inputTypeNode instanceof ListTypeNode) {
+            return newList($this->buildWrappedTypeRecursive($innerType, $inputTypeNode->getType()));
+        }
+
+        if ($inputTypeNode instanceof NonNullTypeNode) {
+            $wrappedType = $this->buildWrappedTypeRecursive($innerType, $inputTypeNode->getType());
+            return newNonNull(assertNullableType($wrappedType));
+        }
+
+        return $innerType;
+    }
+
+    /**
+     * @param array $types
+     * @throws InvalidArgumentException
+     */
+    protected function registerTypes(array $customDirectives)
+    {
+        $typesMap = keyMap(
+            \array_merge($customDirectives, specifiedScalarTypes(), introspectionTypes()),
+            function (NamedTypeInterface $type) {
+                return $type->getName();
+            }
+        );
+
+        foreach ($typesMap as $typeName => $type) {
+            $this->setTypeInCache($typeName, $type);
+        }
+    }
+
+    /**
+     * @param array $directives
+     * @throws InvalidArgumentException
+     */
+    protected function registerDirectives(array $customDirectives)
+    {
+        $directivesMap = keyMap(
+            \array_merge($customDirectives, specifiedDirectives()),
+            function (Directive $directive) {
+                return $directive->getName();
+            }
+        );
+
+        foreach ($directivesMap as $directiveName => $directive) {
+            $this->setDirectiveInCache($directiveName, $directive);
+        }
     }
 
     /**
@@ -275,7 +341,8 @@ class DefinitionBuilder implements DefinitionBuilderInterface
             },
             function ($value) use ($node) {
                 /** @var FieldDefinitionNode|InputValueDefinitionNode $value */
-                return $this->buildField($value, $this->getFieldResolver($node->getNameValue(), $value->getNameValue()));
+                return $this->buildField($value,
+                    $this->getFieldResolver($node->getNameValue(), $value->getNameValue()));
             }
         );
     }
@@ -413,9 +480,10 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     }
 
     /**
-     * @inheritdoc
+     * @param NamedTypeNode $node
+     * @return NamedTypeInterface
      */
-    protected function resolveType(NamedTypeNode $node): ?NamedTypeInterface
+    protected function resolveType(NamedTypeNode $node): NamedTypeInterface
     {
         return \call_user_func($this->resolveTypeFunction, $node);
     }
@@ -423,7 +491,7 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     /**
      * @param NamedTypeNode $node
      * @return NamedTypeInterface|null
-     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function defaultTypeResolver(NamedTypeNode $node): ?NamedTypeInterface
     {
@@ -468,31 +536,90 @@ class DefinitionBuilder implements DefinitionBuilderInterface
     }
 
     /**
+     * @param string $typeName
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    protected function isTypeInCache(string $typeName): bool
+    {
+        return $this->isInCache($this->createTypeCacheKey($typeName));
+    }
+
+    /**
+     * @param string $typeName
+     * @return NamedTypeInterface
+     * @throws InvalidArgumentException
+     */
+    protected function getTypeFromCache(string $typeName): NamedTypeInterface
+    {
+        return $this->getFromCache($this->createTypeCacheKey($typeName));
+    }
+
+    /**
+     * @param string             $typeName
+     * @param NamedTypeInterface $type
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    protected function setTypeInCache(string $typeName, NamedTypeInterface $type): bool
+    {
+        return $this->setInCache($this->createTypeCacheKey($typeName), $type);
+    }
+
+    /**
+     * @param string $typeName
+     * @return string
+     */
+    protected function createTypeCacheKey(string $typeName): string
+    {
+        return $typeName . self::TYPE_CACHE_SUFFIX;
+    }
+
+    /**
+     * @param string $directiveName
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    protected function isDirectiveInCache(string $directiveName): bool
+    {
+        return $this->isInCache($this->createDirectiveCacheKey($directiveName));
+    }
+
+    /**
+     * @param string $directiveName
+     * @return Directive
+     * @throws InvalidArgumentException
+     */
+    protected function getDirectiveFromCache(string $directiveName): Directive
+    {
+        return $this->getFromCache($this->createDirectiveCacheKey($directiveName));
+    }
+
+    /**
+     * @param string    $directiveName
+     * @param Directive $directive
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    protected function setDirectiveInCache(string $directiveName, Directive $directive): bool
+    {
+        return $this->setInCache($this->createDirectiveCacheKey($directiveName), $directive);
+    }
+
+    /**
+     * @param string $directiveName
+     * @return string
+     */
+    protected function createDirectiveCacheKey(string $directiveName): string
+    {
+        return $directiveName . self::DIRECTIVE_CACHE_SUFFIX;
+    }
+
+    /**
      * @return string
      */
     protected function getCachePrefix(): string
     {
         return self::CACHE_PREFIX;
     }
-}
-
-/**
- * @param TypeInterface                        $innerType
- * @param NamedTypeInterface|TypeNodeInterface $inputTypeNode
- * @return TypeInterface
- * @throws InvariantException
- * @throws InvalidTypeException
- */
-function buildWrappedType(TypeInterface $innerType, TypeNodeInterface $inputTypeNode): TypeInterface
-{
-    if ($inputTypeNode instanceof ListTypeNode) {
-        return newList(buildWrappedType($innerType, $inputTypeNode->getType()));
-    }
-
-    if ($inputTypeNode instanceof NonNullTypeNode) {
-        $wrappedType = buildWrappedType($innerType, $inputTypeNode->getType());
-        return newNonNull(assertNullableType($wrappedType));
-    }
-
-    return $innerType;
 }

--- a/src/Schema/DefinitionBuilderInterface.php
+++ b/src/Schema/DefinitionBuilderInterface.php
@@ -7,6 +7,7 @@ use Digia\GraphQL\Language\Node\FieldDefinitionNode;
 use Digia\GraphQL\Language\Node\InputValueDefinitionNode;
 use Digia\GraphQL\Language\Node\NodeInterface;
 use Digia\GraphQL\Type\Definition\Directive;
+use Digia\GraphQL\Type\Definition\NamedTypeInterface;
 use Digia\GraphQL\Type\Definition\TypeInterface;
 
 interface DefinitionBuilderInterface
@@ -19,9 +20,9 @@ interface DefinitionBuilderInterface
 
     /**
      * @param NodeInterface $node
-     * @return TypeInterface
+     * @return NamedTypeInterface
      */
-    public function buildType(NodeInterface $node): TypeInterface;
+    public function buildType(NodeInterface $node): NamedTypeInterface;
 
     /**
      * @param DirectiveDefinitionNode $node

--- a/src/Schema/Extension/SchemaExtender.php
+++ b/src/Schema/Extension/SchemaExtender.php
@@ -26,20 +26,6 @@ use function Digia\GraphQL\Util\toString;
 class SchemaExtender implements SchemaExtenderInterface
 {
     /**
-     * @var CacheInterface
-     */
-    protected $cache;
-
-    /**
-     * BuilderContextCreator constructor.
-     * @param CacheInterface $cache
-     */
-    public function __construct(CacheInterface $cache)
-    {
-        $this->cache = $cache;
-    }
-
-    /**
      * @inheritdoc
      */
     public function extend(
@@ -86,8 +72,7 @@ class SchemaExtender implements SchemaExtenderInterface
             $resolverRegistry,
             $options['types'] ?? [],
             $options['directives'] ?? [],
-            [$context, 'resolveType'],
-            $this->cache
+            [$context, 'resolveType']
         );
 
         return $context->setDefinitionBuilder($definitionBuilder);

--- a/src/Schema/Extension/SchemaExtender.php
+++ b/src/Schema/Extension/SchemaExtender.php
@@ -48,7 +48,7 @@ class SchemaExtender implements SchemaExtenderInterface
         ?ResolverRegistryInterface $resolverRegistry = null,
         array $options = []
     ): Schema {
-        $context = $this->createContext($schema, $document, $resolverRegistry);
+        $context = $this->createContext($schema, $document, $resolverRegistry, $options);
 
         // If this document contains no new types, extensions, or directives then
         // return the same unmodified GraphQLSchema instance.
@@ -69,10 +69,11 @@ class SchemaExtender implements SchemaExtenderInterface
     /**
      * @inheritdoc
      */
-    public function createContext(
+    protected function createContext(
         Schema $schema,
         DocumentNode $document,
-        ?ResolverRegistryInterface $resolverRegistry
+        ?ResolverRegistryInterface $resolverRegistry,
+        array $options
     ): ExtensionContextInterface {
         $info = $this->createInfo($schema, $document);
 
@@ -83,6 +84,8 @@ class SchemaExtender implements SchemaExtenderInterface
         $definitionBuilder = new DefinitionBuilder(
             $info->getTypeDefinitionMap(),
             $resolverRegistry,
+            $options['types'] ?? [],
+            $options['directives'] ?? [],
             [$context, 'resolveType'],
             $this->cache
         );

--- a/src/Schema/Extension/SchemaExtenderInterface.php
+++ b/src/Schema/Extension/SchemaExtenderInterface.php
@@ -21,16 +21,4 @@ interface SchemaExtenderInterface
         ?ResolverRegistryInterface $resolverRegistry = null,
         array $options = []
     ): Schema;
-
-    /**
-     * @param Schema                         $schema
-     * @param DocumentNode                   $document
-     * @param ResolverRegistryInterface|null $resolverRegistry
-     * @return ExtensionContextInterface
-     */
-    public function createContext(
-        Schema $schema,
-        DocumentNode $document,
-        ?ResolverRegistryInterface $resolverRegistry
-    ): ExtensionContextInterface;
 }

--- a/src/Schema/Extension/SchemaExtensionProvider.php
+++ b/src/Schema/Extension/SchemaExtensionProvider.php
@@ -19,7 +19,6 @@ class SchemaExtensionProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        $this->container->add(SchemaExtenderInterface::class, SchemaExtender::class)
-            ->withArgument(CacheInterface::class);
+        $this->container->add(SchemaExtenderInterface::class, SchemaExtender::class);
     }
 }


### PR DESCRIPTION
Initial logic for supporting passing of custom types and directives at build time when using SDL to define your schema.

Here's an example of how you'd use a custom type with your SDL schema:

```php
$schemaDef = file_get_contents(__DIR__ . '/schema.graphqls');

$dateType = newScalarType([
    'name'         => 'Date',
    'serialize'    => function (DateTime $value) {
        return $value->format('Y-m-d');
    },
    'parseValue'   => function ($value) {
        return new DateTime($value);
    },
    'parseLiteral' => function ($node) {
        return $node->getValue();
    },
]);

$executableSchema = buildSchema($schemaDef, [
    'Query' => QueryResolver::class,
], [
    'types' => [$dateType],
]);
```