### PR TITLE
First-class AST

### DIFF
--- a/src/Language/Node/AbstractNode.php
+++ b/src/Language/Node/AbstractNode.php
@@ -24,6 +24,11 @@ abstract class AbstractNode implements NodeInterface, SerializationInterface, Ac
     protected $location;
 
     /**
+     * @return array
+     */
+    abstract public function toAST(): array;
+
+    /**
      * AbstractNode constructor.
      *
      * @param string        $kind
@@ -54,9 +59,17 @@ abstract class AbstractNode implements NodeInterface, SerializationInterface, Ac
     /**
      * @return array|null
      */
-    public function getLocationAsArray(): ?array
+    public function getLocationAST(): ?array
     {
         return null !== $this->location ? $this->location->toArray() : null;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->toAST();
     }
 
     /**

--- a/src/Language/Node/AbstractNode.php
+++ b/src/Language/Node/AbstractNode.php
@@ -60,17 +60,6 @@ abstract class AbstractNode implements NodeInterface, SerializationInterface, Ac
     }
 
     /**
-     * @return array
-     */
-    public function toArray(): array
-    {
-        return [
-            'kind' => $this->kind,
-            'loc'  => $this->getLocationAsArray(),
-        ];
-    }
-
-    /**
      * @return string
      */
     public function __toString(): string

--- a/src/Language/Node/AliasTrait.php
+++ b/src/Language/Node/AliasTrait.php
@@ -29,7 +29,7 @@ trait AliasTrait
     /**
      * @return null|string
      */
-    public function getAliasOrNameValue()
+    public function getAliasOrNameValue(): ?string
     {
         return $this->getAliasValue() ?? $this->getNameValue();
     }
@@ -37,9 +37,9 @@ trait AliasTrait
     /**
      * @return array|null
      */
-    public function getAliasAsArray(): ?array
+    public function getAliasAST(): ?array
     {
-        return null !== $this->alias ? $this->alias->toArray() : null;
+        return null !== $this->alias ? $this->alias->toAST() : null;
     }
 
     /**

--- a/src/Language/Node/ArgumentNode.php
+++ b/src/Language/Node/ArgumentNode.php
@@ -27,13 +27,13 @@ class ArgumentNode extends AbstractNode implements NameAwareInterface
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,
-            'name'  => $this->getNameAsArray(),
-            'value' => $this->getValueAsArray(),
-            'loc'   => $this->getLocationAsArray(),
+            'name'  => $this->getNameAST(),
+            'value' => $this->getValueAST(),
+            'loc'   => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ArgumentsAwareInterface.php
+++ b/src/Language/Node/ArgumentsAwareInterface.php
@@ -17,7 +17,7 @@ interface ArgumentsAwareInterface
     /**
      * @return array
      */
-    public function getArgumentsAsArray(): array;
+    public function getArgumentsAST(): array;
 
     /**
      * @param ArgumentNode[] $arguments

--- a/src/Language/Node/ArgumentsTrait.php
+++ b/src/Language/Node/ArgumentsTrait.php
@@ -2,8 +2,6 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait ArgumentsTrait
 {
     /**
@@ -30,10 +28,10 @@ trait ArgumentsTrait
     /**
      * @return array
      */
-    public function getArgumentsAsArray(): array
+    public function getArgumentsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (ArgumentNode $node) {
+            return $node->toAST();
         }, $this->getArguments());
     }
 

--- a/src/Language/Node/BooleanValueNode.php
+++ b/src/Language/Node/BooleanValueNode.php
@@ -24,12 +24,12 @@ class BooleanValueNode extends AbstractNode implements ValueNodeInterface, Value
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,
             'value' => $this->value,
-            'loc'   => $this->getLocationAsArray(),
+            'loc'   => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/DefaultValueTrait.php
+++ b/src/Language/Node/DefaultValueTrait.php
@@ -2,12 +2,10 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait DefaultValueTrait
 {
     /**
-     * @var ValueNodeInterface|SerializationInterface|null
+     * @var ValueNodeInterface|null
      */
     protected $defaultValue;
 
@@ -20,9 +18,9 @@ trait DefaultValueTrait
     }
 
     /**
-     * @return ValueNodeInterface|SerializationInterface|null
+     * @return ValueNodeInterface|null
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): ?ValueNodeInterface
     {
         return $this->defaultValue;
     }
@@ -30,8 +28,8 @@ trait DefaultValueTrait
     /**
      * @return array
      */
-    public function getDefaultValueAsArray(): ?array
+    public function getDefaultValueAST(): ?array
     {
-        return null !== $this->defaultValue ? $this->defaultValue->toArray() : null;
+        return null !== $this->defaultValue ? $this->defaultValue->toAST() : null;
     }
 }

--- a/src/Language/Node/DescriptionTrait.php
+++ b/src/Language/Node/DescriptionTrait.php
@@ -28,9 +28,9 @@ trait DescriptionTrait
     /**
      * @return array|null
      */
-    public function getDescriptionAsArray(): ?array
+    public function getDescriptionAST(): ?array
     {
-        return null !== $this->description ? $this->description->toArray() : null;
+        return null !== $this->description ? $this->description->toAST() : null;
     }
 
     /**

--- a/src/Language/Node/DirectiveDefinitionNode.php
+++ b/src/Language/Node/DirectiveDefinitionNode.php
@@ -3,7 +3,6 @@
 namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
-use Digia\GraphQL\Util\SerializationInterface;
 
 class DirectiveDefinitionNode extends AbstractNode implements DefinitionNodeInterface, NameAwareInterface
 {
@@ -51,10 +50,10 @@ class DirectiveDefinitionNode extends AbstractNode implements DefinitionNodeInte
     /**
      * @return array
      */
-    public function getLocationsAsArray(): array
+    public function getLocationsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (NameNode $node) {
+            return $node->toAST();
         }, $this->locations);
     }
 
@@ -71,15 +70,15 @@ class DirectiveDefinitionNode extends AbstractNode implements DefinitionNodeInte
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'arguments'   => $this->getArgumentsAsArray(),
-            'locations'   => $this->getLocationsAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'arguments'   => $this->getArgumentsAST(),
+            'locations'   => $this->getLocationsAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/DirectiveNode.php
+++ b/src/Language/Node/DirectiveNode.php
@@ -27,13 +27,13 @@ class DirectiveNode extends AbstractNode implements ArgumentsAwareInterface, Nam
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'      => $this->kind,
-            'name'      => $this->getNameAsArray(),
-            'arguments' => $this->getArgumentsAsArray(),
-            'location'  => $this->getLocationAsArray(),
+            'name'      => $this->getNameAST(),
+            'arguments' => $this->getArgumentsAST(),
+            'location'  => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/DirectiveNode.php
+++ b/src/Language/Node/DirectiveNode.php
@@ -30,10 +30,10 @@ class DirectiveNode extends AbstractNode implements ArgumentsAwareInterface, Nam
     public function toArray(): array
     {
         return [
-            'kind' => $this->kind,
-            'name' => $this->getNameAsArray(),
+            'kind'      => $this->kind,
+            'name'      => $this->getNameAsArray(),
             'arguments' => $this->getArgumentsAsArray(),
-            'location' => $this->getLocationAsArray(),
+            'location'  => $this->getLocationAsArray(),
         ];
     }
 }

--- a/src/Language/Node/DirectivesAwareInterface.php
+++ b/src/Language/Node/DirectivesAwareInterface.php
@@ -17,7 +17,7 @@ interface DirectivesAwareInterface
     /**
      * @return array
      */
-    public function getDirectivesAsArray(): array;
+    public function getDirectivesAST(): array;
 
     /**
      * @param DirectiveNode[] $directives

--- a/src/Language/Node/DirectivesTrait.php
+++ b/src/Language/Node/DirectivesTrait.php
@@ -28,10 +28,10 @@ trait DirectivesTrait
     /**
      * @return array
      */
-    public function getDirectivesAsArray(): array
+    public function getDirectivesAST(): array
     {
         return \array_map(function (DirectiveNode $directive) {
-            return $directive->toArray();
+            return $directive->toAST();
         }, $this->directives);
     }
 

--- a/src/Language/Node/DocumentNode.php
+++ b/src/Language/Node/DocumentNode.php
@@ -3,12 +3,11 @@
 namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
-use Digia\GraphQL\Util\SerializationInterface;
 
 class DocumentNode extends AbstractNode
 {
     /**
-     * @var DefinitionNodeInterface[]
+     * @var DefinitionNodeInterface[]|TypeExtensionNodeInterface[]
      */
     protected $definitions;
 
@@ -26,7 +25,7 @@ class DocumentNode extends AbstractNode
     }
 
     /**
-     * @return DefinitionNodeInterface[]
+     * @return DefinitionNodeInterface[]|TypeExtensionNodeInterface[]
      */
     public function getDefinitions(): array
     {
@@ -36,22 +35,22 @@ class DocumentNode extends AbstractNode
     /**
      * @return array
      */
-    public function getDefinitionsAsArray(): array
+    public function getDefinitionsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (NodeInterface $node) {
+            return $node->toAST();
         }, $this->definitions);
     }
 
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'definitions' => $this->getDefinitionsAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'definitions' => $this->getDefinitionsAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 

--- a/src/Language/Node/EnumTypeDefinitionNode.php
+++ b/src/Language/Node/EnumTypeDefinitionNode.php
@@ -39,15 +39,15 @@ class EnumTypeDefinitionNode extends AbstractNode implements TypeDefinitionNodeI
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'values'      => $this->getValuesAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'values'      => $this->getValuesAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/EnumTypeExtensionNode.php
+++ b/src/Language/Node/EnumTypeExtensionNode.php
@@ -31,14 +31,14 @@ class EnumTypeExtensionNode extends AbstractNode implements TypeExtensionNodeInt
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'       => $this->kind,
-            'name'       => $this->getNameAsArray(),
-            'directives' => $this->getDirectivesAsArray(),
-            'values'     => $this->getValuesAsArray(),
-            'loc'        => $this->getLocationAsArray(),
+            'name'       => $this->getNameAST(),
+            'directives' => $this->getDirectivesAST(),
+            'values'     => $this->getValuesAST(),
+            'loc'        => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/EnumValueDefinitionNode.php
+++ b/src/Language/Node/EnumValueDefinitionNode.php
@@ -35,14 +35,14 @@ class EnumValueDefinitionNode extends AbstractNode implements DefinitionNodeInte
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/EnumValueNode.php
+++ b/src/Language/Node/EnumValueNode.php
@@ -32,7 +32,7 @@ class EnumValueNode extends AbstractNode implements ValueNodeInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,

--- a/src/Language/Node/EnumValueNode.php
+++ b/src/Language/Node/EnumValueNode.php
@@ -28,4 +28,15 @@ class EnumValueNode extends AbstractNode implements ValueNodeInterface
     {
         return (string)$this->value;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind'  => $this->kind,
+            'value' => $this->value,
+        ];
+    }
 }

--- a/src/Language/Node/EnumValuesTrait.php
+++ b/src/Language/Node/EnumValuesTrait.php
@@ -2,8 +2,6 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait EnumValuesTrait
 {
     /**
@@ -30,10 +28,10 @@ trait EnumValuesTrait
     /**
      * @return array
      */
-    public function getValuesAsArray(): array
+    public function getValuesAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (EnumValueDefinitionNode $node) {
+            return $node->toAST();
         }, $this->values);
     }
 

--- a/src/Language/Node/ExecutableDefinitionNodeInterface.php
+++ b/src/Language/Node/ExecutableDefinitionNodeInterface.php
@@ -4,6 +4,8 @@ namespace Digia\GraphQL\Language\Node;
 
 interface ExecutableDefinitionNodeInterface extends DefinitionNodeInterface
 {
+    // TODO: Figure out of the `getNameValue` method can be moved to `DefinitionNodeInterface`.
+
     /**
      * @return null|string
      */

--- a/src/Language/Node/FieldDefinitionNode.php
+++ b/src/Language/Node/FieldDefinitionNode.php
@@ -43,16 +43,16 @@ class FieldDefinitionNode extends AbstractNode implements DefinitionNodeInterfac
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
             'description' => $this->description,
-            'name'        => $this->getNameAsArray(),
-            'arguments'   => $this->getArgumentsAsArray(),
-            'type'        => $this->getTypeAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'name'        => $this->getNameAST(),
+            'arguments'   => $this->getArgumentsAST(),
+            'type'        => $this->getTypeAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/FieldNode.php
+++ b/src/Language/Node/FieldNode.php
@@ -43,16 +43,16 @@ class FieldNode extends AbstractNode implements SelectionNodeInterface, Argument
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'         => $this->kind,
-            'loc'          => $this->getLocationAsArray(),
-            'alias'        => $this->getAliasAsArray(),
-            'name'         => $this->getNameAsArray(),
-            'arguments'    => $this->getArgumentsAsArray(),
-            'directives'   => $this->getDirectivesAsArray(),
-            'selectionSet' => $this->getSelectionSetAsArray(),
+            'loc'          => $this->getLocationAST(),
+            'alias'        => $this->getAliasAST(),
+            'name'         => $this->getNameAST(),
+            'arguments'    => $this->getArgumentsAST(),
+            'directives'   => $this->getDirectivesAST(),
+            'selectionSet' => $this->getSelectionSetAST(),
         ];
     }
 }

--- a/src/Language/Node/FieldsTrait.php
+++ b/src/Language/Node/FieldsTrait.php
@@ -2,8 +2,6 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait FieldsTrait
 {
     /**
@@ -30,10 +28,10 @@ trait FieldsTrait
     /**
      * @return array
      */
-    public function getFieldsAsArray(): array
+    public function getFieldsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (FieldDefinitionNode $node) {
+            return $node->toAST();
         }, $this->fields);
     }
 

--- a/src/Language/Node/FloatValueNode.php
+++ b/src/Language/Node/FloatValueNode.php
@@ -24,11 +24,11 @@ class FloatValueNode extends AbstractNode implements ValueNodeInterface, ValueAw
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,
-            'loc'   => $this->getLocationAsArray(),
+            'loc'   => $this->getLocationAST(),
             'value' => $this->value,
         ];
     }

--- a/src/Language/Node/FragmentDefinitionNode.php
+++ b/src/Language/Node/FragmentDefinitionNode.php
@@ -43,16 +43,16 @@ class FragmentDefinitionNode extends AbstractNode implements ExecutableDefinitio
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'                => $this->kind,
-            'name'                => $this->getNameAsArray(),
-            'variableDefinitions' => $this->getVariableDefinitionsAsArray(),
-            'typeCondition'       => $this->getTypeConditionAsArray(),
-            'directives'          => $this->getDirectivesAsArray(),
-            'selectionSet'        => $this->getSelectionSetAsArray(),
-            'loc'                 => $this->getLocationAsArray(),
+            'name'                => $this->getNameAST(),
+            'variableDefinitions' => $this->getVariableDefinitionsAST(),
+            'typeCondition'       => $this->getTypeConditionAST(),
+            'directives'          => $this->getDirectivesAST(),
+            'selectionSet'        => $this->getSelectionSetAST(),
+            'loc'                 => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/FragmentDefinitionNode.php
+++ b/src/Language/Node/FragmentDefinitionNode.php
@@ -46,11 +46,13 @@ class FragmentDefinitionNode extends AbstractNode implements ExecutableDefinitio
     public function toArray(): array
     {
         return [
+            'kind'                => $this->kind,
             'name'                => $this->getNameAsArray(),
             'variableDefinitions' => $this->getVariableDefinitionsAsArray(),
             'typeCondition'       => $this->getTypeConditionAsArray(),
             'directives'          => $this->getDirectivesAsArray(),
             'selectionSet'        => $this->getSelectionSetAsArray(),
+            'loc'                 => $this->getLocationAsArray(),
         ];
     }
 }

--- a/src/Language/Node/FragmentSpreadNode.php
+++ b/src/Language/Node/FragmentSpreadNode.php
@@ -30,4 +30,18 @@ class FragmentSpreadNode extends AbstractNode implements FragmentNodeInterface, 
         $this->directives   = $directives;
         $this->selectionSet = $selectionSet;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind'         => $this->kind,
+            'name'         => $this->getNameAsArray(),
+            'directives'   => $this->getDirectivesAsArray(),
+            'selectionSet' => $this->getSelectionSetAsArray(),
+            'loc'          => $this->getLocationAsArray(),
+        ];
+    }
 }

--- a/src/Language/Node/FragmentSpreadNode.php
+++ b/src/Language/Node/FragmentSpreadNode.php
@@ -4,7 +4,8 @@ namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
 
-class FragmentSpreadNode extends AbstractNode implements FragmentNodeInterface, NameAwareInterface
+class FragmentSpreadNode extends AbstractNode implements FragmentNodeInterface, NameAwareInterface,
+    SelectionNodeInterface
 {
     use NameTrait;
     use DirectivesTrait;
@@ -34,14 +35,14 @@ class FragmentSpreadNode extends AbstractNode implements FragmentNodeInterface, 
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'         => $this->kind,
-            'name'         => $this->getNameAsArray(),
-            'directives'   => $this->getDirectivesAsArray(),
-            'selectionSet' => $this->getSelectionSetAsArray(),
-            'loc'          => $this->getLocationAsArray(),
+            'name'         => $this->getNameAST(),
+            'directives'   => $this->getDirectivesAST(),
+            'selectionSet' => $this->getSelectionSetAST(),
+            'loc'          => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/InlineFragmentNode.php
+++ b/src/Language/Node/InlineFragmentNode.php
@@ -4,7 +4,7 @@ namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
 
-class InlineFragmentNode extends AbstractNode implements FragmentNodeInterface
+class InlineFragmentNode extends AbstractNode implements FragmentNodeInterface, SelectionNodeInterface
 {
     use DirectivesTrait;
     use TypeConditionTrait;
@@ -34,14 +34,14 @@ class InlineFragmentNode extends AbstractNode implements FragmentNodeInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'          => $this->kind,
-            'typeCondition' => $this->getTypeConditionAsArray(),
-            'directives'    => $this->getDirectivesAsArray(),
-            'selectionSet'  => $this->getSelectionSetAsArray(),
-            'loc'           => $this->getLocationAsArray(),
+            'typeCondition' => $this->getTypeConditionAST(),
+            'directives'    => $this->getDirectivesAST(),
+            'selectionSet'  => $this->getSelectionSetAST(),
+            'loc'           => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/InlineFragmentNode.php
+++ b/src/Language/Node/InlineFragmentNode.php
@@ -37,9 +37,11 @@ class InlineFragmentNode extends AbstractNode implements FragmentNodeInterface
     public function toArray(): array
     {
         return [
+            'kind'          => $this->kind,
             'typeCondition' => $this->getTypeConditionAsArray(),
-            'directives' => $this->getDirectivesAsArray(),
-            'selectionSet' => $this->getSelectionSetAsArray(),
+            'directives'    => $this->getDirectivesAsArray(),
+            'selectionSet'  => $this->getSelectionSetAsArray(),
+            'loc'           => $this->getLocationAsArray(),
         ];
     }
 }

--- a/src/Language/Node/InputArgumentsTrait.php
+++ b/src/Language/Node/InputArgumentsTrait.php
@@ -2,11 +2,8 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait InputArgumentsTrait
 {
-
     /**
      * @var InputValueDefinitionNode[]
      */
@@ -31,10 +28,10 @@ trait InputArgumentsTrait
     /**
      * @return array
      */
-    public function getArgumentsAsArray(): array
+    public function getArgumentsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (InputValueDefinitionNode $node) {
+            return $node->toAST();
         }, $this->arguments);
     }
 

--- a/src/Language/Node/InputFieldsTrait.php
+++ b/src/Language/Node/InputFieldsTrait.php
@@ -2,11 +2,8 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait InputFieldsTrait
 {
-
     /**
      * @var InputValueDefinitionNode[]
      */
@@ -31,10 +28,10 @@ trait InputFieldsTrait
     /**
      * @return array
      */
-    public function getFieldsAsArray(): array
+    public function getFieldsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (InputValueDefinitionNode $node) {
+            return $node->toAST();
         }, $this->fields);
     }
 

--- a/src/Language/Node/InputObjectTypeDefinitionNode.php
+++ b/src/Language/Node/InputObjectTypeDefinitionNode.php
@@ -39,15 +39,15 @@ class InputObjectTypeDefinitionNode extends AbstractNode implements TypeDefiniti
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'fields'      => $this->getFieldsAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'fields'      => $this->getFieldsAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/InputObjectTypeExtensionNode.php
+++ b/src/Language/Node/InputObjectTypeExtensionNode.php
@@ -4,8 +4,8 @@ namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
 
-class InputObjectTypeExtensionNode extends AbstractNode implements TypeExtensionNodeInterface,
-    DirectivesAwareInterface, NameAwareInterface
+class InputObjectTypeExtensionNode extends AbstractNode implements TypeExtensionNodeInterface, DirectivesAwareInterface,
+    NameAwareInterface
 {
     use NameTrait;
     use DirectivesTrait;
@@ -35,14 +35,14 @@ class InputObjectTypeExtensionNode extends AbstractNode implements TypeExtension
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'       => $this->kind,
-            'name'       => $this->getNameAsArray(),
-            'directives' => $this->getDirectivesAsArray(),
-            'fields'     => $this->getFieldsAsArray(),
-            'loc'        => $this->getLocationAsArray(),
+            'name'       => $this->getNameAST(),
+            'directives' => $this->getDirectivesAST(),
+            'fields'     => $this->getFieldsAST(),
+            'loc'        => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/InputValueDefinitionNode.php
+++ b/src/Language/Node/InputValueDefinitionNode.php
@@ -43,16 +43,16 @@ class InputValueDefinitionNode extends AbstractNode implements DefinitionNodeInt
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'         => $this->kind,
-            'description'  => $this->getDescriptionAsArray(),
-            'name'         => $this->getNameAsArray(),
-            'type'         => $this->getTypeAsArray(),
-            'defaultValue' => $this->getDefaultValueAsArray(),
-            'directives'   => $this->getDirectivesAsArray(),
-            'loc'          => $this->getLocationAsArray(),
+            'description'  => $this->getDescriptionAST(),
+            'name'         => $this->getNameAST(),
+            'type'         => $this->getTypeAST(),
+            'defaultValue' => $this->getDefaultValueAST(),
+            'directives'   => $this->getDirectivesAST(),
+            'loc'          => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/IntValueNode.php
+++ b/src/Language/Node/IntValueNode.php
@@ -24,11 +24,11 @@ class IntValueNode extends AbstractNode implements ValueNodeInterface, ValueAwar
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,
-            'loc'   => $this->getLocationAsArray(),
+            'loc'   => $this->getLocationAST(),
             'value' => $this->value,
         ];
     }

--- a/src/Language/Node/InterfaceTypeDefinitionNode.php
+++ b/src/Language/Node/InterfaceTypeDefinitionNode.php
@@ -39,15 +39,15 @@ class InterfaceTypeDefinitionNode extends AbstractNode implements TypeDefinition
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'fields'      => $this->getFieldsAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'fields'      => $this->getFieldsAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/InterfaceTypeExtensionNode.php
+++ b/src/Language/Node/InterfaceTypeExtensionNode.php
@@ -4,8 +4,8 @@ namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
 
-class InterfaceTypeExtensionNode extends AbstractNode implements TypeExtensionNodeInterface,
-    DirectivesAwareInterface, NameAwareInterface
+class InterfaceTypeExtensionNode extends AbstractNode implements TypeExtensionNodeInterface, DirectivesAwareInterface,
+    NameAwareInterface
 {
     use NameTrait;
     use DirectivesTrait;
@@ -31,14 +31,14 @@ class InterfaceTypeExtensionNode extends AbstractNode implements TypeExtensionNo
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'       => $this->kind,
-            'name'       => $this->getNameAsArray(),
-            'directives' => $this->getDirectivesAsArray(),
-            'fields'     => $this->getFieldsAsArray(),
-            'loc'        => $this->getLocationAsArray(),
+            'name'       => $this->getNameAST(),
+            'directives' => $this->getDirectivesAST(),
+            'fields'     => $this->getFieldsAST(),
+            'loc'        => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/InterfacesTrait.php
+++ b/src/Language/Node/InterfacesTrait.php
@@ -2,11 +2,8 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait InterfacesTrait
 {
-
     /**
      * @var NamedTypeNode[]
      */
@@ -31,10 +28,10 @@ trait InterfacesTrait
     /**
      * @return array
      */
-    public function getInterfacesAsArray(): array
+    public function getInterfacesAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (NamedTypeNode $node) {
+            return $node->toAST();
         }, $this->interfaces);
     }
 

--- a/src/Language/Node/ListTypeNode.php
+++ b/src/Language/Node/ListTypeNode.php
@@ -24,12 +24,12 @@ class ListTypeNode extends AbstractNode implements TypeNodeInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind' => $this->kind,
-            'type' => $this->getTypeAsArray(),
-            'loc'  => $this->getLocationAsArray(),
+            'type' => $this->getTypeAST(),
+            'loc'  => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ListValueNode.php
+++ b/src/Language/Node/ListValueNode.php
@@ -3,7 +3,6 @@
 namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
-use Digia\GraphQL\Util\SerializationInterface;
 
 class ListValueNode extends AbstractNode implements ValueNodeInterface
 {
@@ -36,10 +35,10 @@ class ListValueNode extends AbstractNode implements ValueNodeInterface
     /**
      * @return array
      */
-    public function getValuesAsArray(): array
+    public function getValuesAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (ValueNodeInterface $node) {
+            return $node->toAST();
         }, $this->values);
     }
 
@@ -56,12 +55,12 @@ class ListValueNode extends AbstractNode implements ValueNodeInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'   => $this->kind,
-            'loc'    => $this->getLocationAsArray(),
-            'values' => $this->getValuesAsArray(),
+            'loc'    => $this->getLocationAST(),
+            'values' => $this->getValuesAST(),
         ];
     }
 

--- a/src/Language/Node/NameAwareInterface.php
+++ b/src/Language/Node/NameAwareInterface.php
@@ -17,7 +17,7 @@ interface NameAwareInterface
     /**
      * @return array|null
      */
-    public function getNameAsArray(): ?array;
+    public function getNameAST(): ?array;
 
     /**
      * @param NameNode|null $name

--- a/src/Language/Node/NameNode.php
+++ b/src/Language/Node/NameNode.php
@@ -29,12 +29,12 @@ class NameNode extends AbstractNode
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,
             'value' => $this->value,
-            'loc'   => $this->getLocationAsArray(),
+            'loc'   => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/NameTrait.php
+++ b/src/Language/Node/NameTrait.php
@@ -28,7 +28,7 @@ trait NameTrait
     /**
      * @return array|null
      */
-    public function getNameAsArray(): ?array
+    public function getNameAST(): ?array
     {
         return null !== $this->name ? $this->name->toArray() : null;
     }

--- a/src/Language/Node/NamedTypeNode.php
+++ b/src/Language/Node/NamedTypeNode.php
@@ -24,12 +24,12 @@ class NamedTypeNode extends AbstractNode implements TypeNodeInterface, NameAware
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind' => $this->kind,
-            'name' => $this->getNameAsArray(),
-            'loc'  => $this->getLocationAsArray(),
+            'name' => $this->getNameAST(),
+            'loc'  => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/NodeInterface.php
+++ b/src/Language/Node/NodeInterface.php
@@ -18,6 +18,11 @@ interface NodeInterface
     public function getLocation(): ?Location;
 
     /**
+     * @return array
+     */
+    public function toAST(): array;
+
+    /**
      * @return string
      */
     public function toJSON(): string;

--- a/src/Language/Node/NonNullTypeNode.php
+++ b/src/Language/Node/NonNullTypeNode.php
@@ -24,12 +24,12 @@ class NonNullTypeNode extends AbstractNode implements TypeNodeInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind' => $this->kind,
-            'type' => $this->getTypeAsArray(),
-            'loc'  => $this->getLocationAsArray(),
+            'type' => $this->getTypeAST(),
+            'loc'  => $this->getLocationAST(),
         ];
     }
 

--- a/src/Language/Node/NullValueNode.php
+++ b/src/Language/Node/NullValueNode.php
@@ -15,4 +15,15 @@ class NullValueNode extends AbstractNode implements ValueNodeInterface
     {
         parent::__construct(NodeKindEnum::NULL, $location);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind' => $this->kind,
+            'loc'  => $this->getLocationAsArray(),
+        ];
+    }
 }

--- a/src/Language/Node/NullValueNode.php
+++ b/src/Language/Node/NullValueNode.php
@@ -19,11 +19,11 @@ class NullValueNode extends AbstractNode implements ValueNodeInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind' => $this->kind,
-            'loc'  => $this->getLocationAsArray(),
+            'loc'  => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ObjectFieldNode.php
+++ b/src/Language/Node/ObjectFieldNode.php
@@ -27,13 +27,13 @@ class ObjectFieldNode extends AbstractNode implements NameAwareInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,
-            'name'  => $this->getNameAsArray(),
-            'value' => $this->getValueAsArray(),
-            'loc'   => $this->getLocationAsArray(),
+            'name'  => $this->getNameAST(),
+            'value' => $this->getValueAST(),
+            'loc'   => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ObjectFieldNode.php
+++ b/src/Language/Node/ObjectFieldNode.php
@@ -23,4 +23,17 @@ class ObjectFieldNode extends AbstractNode implements NameAwareInterface
         $this->name  = $name;
         $this->value = $value;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind'  => $this->kind,
+            'name'  => $this->getNameAsArray(),
+            'value' => $this->getValueAsArray(),
+            'loc'   => $this->getLocationAsArray(),
+        ];
+    }
 }

--- a/src/Language/Node/ObjectTypeDefinitionNode.php
+++ b/src/Language/Node/ObjectTypeDefinitionNode.php
@@ -43,16 +43,16 @@ class ObjectTypeDefinitionNode extends AbstractNode implements TypeDefinitionNod
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'interfaces'  => $this->getInterfacesAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'fields'      => $this->getFieldsAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'interfaces'  => $this->getInterfacesAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'fields'      => $this->getFieldsAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ObjectTypeExtensionNode.php
+++ b/src/Language/Node/ObjectTypeExtensionNode.php
@@ -39,15 +39,15 @@ class ObjectTypeExtensionNode extends AbstractNode implements TypeExtensionNodeI
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'       => $this->kind,
-            'name'       => $this->getNameAsArray(),
-            'interfaces' => $this->getInterfacesAsArray(),
-            'directives' => $this->getDirectivesAsArray(),
-            'fields'     => $this->getFieldsAsArray(),
-            'loc'        => $this->getLocationAsArray(),
+            'name'       => $this->getNameAST(),
+            'interfaces' => $this->getInterfacesAST(),
+            'directives' => $this->getDirectivesAST(),
+            'fields'     => $this->getFieldsAST(),
+            'loc'        => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ObjectValueNode.php
+++ b/src/Language/Node/ObjectValueNode.php
@@ -52,4 +52,15 @@ class ObjectValueNode extends AbstractNode implements ValueNodeInterface
         $this->fields = $fields;
         return $this;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind'   => $this->kind,
+            'fields' => $this->getFieldsAsArray(),
+        ];
+    }
 }

--- a/src/Language/Node/ObjectValueNode.php
+++ b/src/Language/Node/ObjectValueNode.php
@@ -3,7 +3,6 @@
 namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
-use Digia\GraphQL\Util\SerializationInterface;
 
 class ObjectValueNode extends AbstractNode implements ValueNodeInterface
 {
@@ -36,10 +35,10 @@ class ObjectValueNode extends AbstractNode implements ValueNodeInterface
     /**
      * @return array
      */
-    public function getFieldsAsArray(): array
+    public function getFieldsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (ObjectFieldNode $node) {
+            return $node->toAST();
         }, $this->fields);
     }
 
@@ -56,11 +55,11 @@ class ObjectValueNode extends AbstractNode implements ValueNodeInterface
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'   => $this->kind,
-            'fields' => $this->getFieldsAsArray(),
+            'fields' => $this->getFieldsAST(),
         ];
     }
 }

--- a/src/Language/Node/OperationDefinitionNode.php
+++ b/src/Language/Node/OperationDefinitionNode.php
@@ -55,16 +55,16 @@ class OperationDefinitionNode extends AbstractNode implements ExecutableDefiniti
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'                => $this->kind,
-            'loc'                 => $this->getLocationAsArray(),
+            'loc'                 => $this->getLocationAST(),
             'operation'           => $this->operation,
-            'name'                => $this->getNameAsArray(),
-            'variableDefinitions' => $this->getVariableDefinitionsAsArray(),
-            'directives'          => $this->getDirectivesAsArray(),
-            'selectionSet'        => $this->getSelectionSetAsArray(),
+            'name'                => $this->getNameAST(),
+            'variableDefinitions' => $this->getVariableDefinitionsAST(),
+            'directives'          => $this->getDirectivesAST(),
+            'selectionSet'        => $this->getSelectionSetAST(),
         ];
     }
 }

--- a/src/Language/Node/OperationTypeDefinitionNode.php
+++ b/src/Language/Node/OperationTypeDefinitionNode.php
@@ -39,13 +39,13 @@ class OperationTypeDefinitionNode extends AbstractNode implements DefinitionNode
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'      => $this->kind,
             'operation' => $this->operation,
-            'type'      => $this->getTypeAsArray(),
-            'loc'       => $this->getLocationAsArray(),
+            'type'      => $this->getTypeAST(),
+            'loc'       => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ScalarTypeDefinitionNode.php
+++ b/src/Language/Node/ScalarTypeDefinitionNode.php
@@ -31,14 +31,14 @@ class ScalarTypeDefinitionNode extends AbstractNode implements TypeDefinitionNod
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ScalarTypeExtensionNode.php
+++ b/src/Language/Node/ScalarTypeExtensionNode.php
@@ -28,13 +28,13 @@ class ScalarTypeExtensionNode extends AbstractNode implements TypeExtensionNodeI
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'       => $this->kind,
-            'name'       => $this->getNameAsArray(),
-            'directives' => $this->getDirectivesAsArray(),
-            'loc'        => $this->getLocationAsArray(),
+            'name'       => $this->getNameAST(),
+            'directives' => $this->getDirectivesAST(),
+            'loc'        => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/SchemaDefinitionNode.php
+++ b/src/Language/Node/SchemaDefinitionNode.php
@@ -3,7 +3,6 @@
 namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
-use Digia\GraphQL\Util\SerializationInterface;
 
 class SchemaDefinitionNode extends AbstractNode implements TypeSystemDefinitionNodeInterface
 {
@@ -40,10 +39,10 @@ class SchemaDefinitionNode extends AbstractNode implements TypeSystemDefinitionN
     /**
      * @return array
      */
-    public function getOperationTypesAsArray(): array
+    public function getOperationTypesAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (OperationTypeDefinitionNode $node) {
+            return $node->toAST();
         }, $this->operationTypes);
     }
 
@@ -60,13 +59,13 @@ class SchemaDefinitionNode extends AbstractNode implements TypeSystemDefinitionN
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'           => $this->kind,
-            'directives'     => $this->getDirectivesAsArray(),
-            'operationTypes' => $this->getOperationTypesAsArray(),
-            'loc'            => $this->getLocationAsArray(),
+            'directives'     => $this->getDirectivesAST(),
+            'operationTypes' => $this->getOperationTypesAST(),
+            'loc'            => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/SelectionNodeInterface.php
+++ b/src/Language/Node/SelectionNodeInterface.php
@@ -4,5 +4,4 @@ namespace Digia\GraphQL\Language\Node;
 
 interface SelectionNodeInterface extends NodeInterface
 {
-
 }

--- a/src/Language/Node/SelectionSetNode.php
+++ b/src/Language/Node/SelectionSetNode.php
@@ -3,7 +3,6 @@
 namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
-use Digia\GraphQL\Util\SerializationInterface;
 
 class SelectionSetNode extends AbstractNode
 {
@@ -36,10 +35,10 @@ class SelectionSetNode extends AbstractNode
     /**
      * @return array
      */
-    public function getSelectionsAsArray(): array
+    public function getSelectionsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (SelectionNodeInterface $node) {
+            return $node->toAST();
         }, $this->selections);
     }
 
@@ -56,12 +55,12 @@ class SelectionSetNode extends AbstractNode
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'       => $this->kind,
-            'loc'        => $this->getLocationAsArray(),
-            'selections' => $this->getSelectionsAsArray(),
+            'loc'        => $this->getLocationAST(),
+            'selections' => $this->getSelectionsAST(),
         ];
     }
 }

--- a/src/Language/Node/SelectionSetTrait.php
+++ b/src/Language/Node/SelectionSetTrait.php
@@ -29,7 +29,7 @@ trait SelectionSetTrait
     /**
      * @return array|null
      */
-    public function getSelectionSetAsArray(): ?array
+    public function getSelectionSetAST(): ?array
     {
         return null !== $this->selectionSet ? $this->selectionSet->toArray() : null;
     }

--- a/src/Language/Node/StringValueNode.php
+++ b/src/Language/Node/StringValueNode.php
@@ -39,11 +39,11 @@ class StringValueNode extends AbstractNode implements ValueNodeInterface, ValueA
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'  => $this->kind,
-            'loc'   => $this->getLocationAsArray(),
+            'loc'   => $this->getLocationAST(),
             'block' => $this->block,
             'value' => $this->value,
         ];

--- a/src/Language/Node/TypeConditionTrait.php
+++ b/src/Language/Node/TypeConditionTrait.php
@@ -20,9 +20,9 @@ trait TypeConditionTrait
     /**
      * @return array|null
      */
-    public function getTypeConditionAsArray(): ?array
+    public function getTypeConditionAST(): ?array
     {
-        return null !== $this->typeCondition ? $this->typeCondition->toArray() : null;
+        return null !== $this->typeCondition ? $this->typeCondition->toAST() : null;
     }
 
     /**

--- a/src/Language/Node/TypeExtensionNodeInterface.php
+++ b/src/Language/Node/TypeExtensionNodeInterface.php
@@ -4,5 +4,4 @@ namespace Digia\GraphQL\Language\Node;
 
 interface TypeExtensionNodeInterface extends NodeInterface
 {
-
 }

--- a/src/Language/Node/TypeNodeInterface.php
+++ b/src/Language/Node/TypeNodeInterface.php
@@ -4,5 +4,4 @@ namespace Digia\GraphQL\Language\Node;
 
 interface TypeNodeInterface extends NodeInterface
 {
-
 }

--- a/src/Language/Node/TypeSystemDefinitionNodeInterface.php
+++ b/src/Language/Node/TypeSystemDefinitionNodeInterface.php
@@ -4,5 +4,4 @@ namespace Digia\GraphQL\Language\Node;
 
 interface TypeSystemDefinitionNodeInterface extends DefinitionNodeInterface
 {
-
 }

--- a/src/Language/Node/TypeTrait.php
+++ b/src/Language/Node/TypeTrait.php
@@ -2,17 +2,15 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait TypeTrait
 {
     /**
-     * @var TypeNodeInterface|SerializationInterface
+     * @var TypeNodeInterface
      */
     protected $type;
 
     /**
-     * @return TypeNodeInterface|SerializationInterface
+     * @return TypeNodeInterface
      */
     public function getType()
     {
@@ -22,13 +20,13 @@ trait TypeTrait
     /**
      * @return array
      */
-    public function getTypeAsArray(): array
+    public function getTypeAST(): array
     {
-        return $this->type->toArray();
+        return $this->type->toAST();
     }
 
     /**
-     * @param TypeNodeInterface|SerializationInterface $type
+     * @param TypeNodeInterface $type
      * @return $this
      */
     public function setType($type)

--- a/src/Language/Node/TypesTrait.php
+++ b/src/Language/Node/TypesTrait.php
@@ -2,8 +2,6 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait TypesTrait
 {
     /**
@@ -30,10 +28,10 @@ trait TypesTrait
     /**
      * @return array
      */
-    public function getTypesAsArray(): array
+    public function getTypesAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (NamedTypeNode $node) {
+            return $node->toAST();
         }, $this->types);
     }
 

--- a/src/Language/Node/UnionTypeDefinitionNode.php
+++ b/src/Language/Node/UnionTypeDefinitionNode.php
@@ -38,15 +38,15 @@ class UnionTypeDefinitionNode extends AbstractNode implements TypeDefinitionNode
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'        => $this->kind,
-            'description' => $this->getDescriptionAsArray(),
-            'name'        => $this->getNameAsArray(),
-            'directives'  => $this->getDirectivesAsArray(),
-            'types'       => $this->getTypesAsArray(),
-            'loc'         => $this->getLocationAsArray(),
+            'description' => $this->getDescriptionAST(),
+            'name'        => $this->getNameAST(),
+            'directives'  => $this->getDirectivesAST(),
+            'types'       => $this->getTypesAST(),
+            'loc'         => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/UnionTypeExtensionNode.php
+++ b/src/Language/Node/UnionTypeExtensionNode.php
@@ -31,14 +31,14 @@ class UnionTypeExtensionNode extends AbstractNode implements TypeExtensionNodeIn
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'       => $this->kind,
-            'name'       => $this->getNameAsArray(),
-            'directives' => $this->getDirectivesAsArray(),
-            'types'      => $this->getTypesAsArray(),
-            'loc'        => $this->getLocationAsArray(),
+            'name'       => $this->getNameAST(),
+            'directives' => $this->getDirectivesAST(),
+            'types'      => $this->getTypesAST(),
+            'loc'        => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/ValueLiteralTrait.php
+++ b/src/Language/Node/ValueLiteralTrait.php
@@ -2,18 +2,15 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait ValueLiteralTrait
 {
-
     /**
-     * @var ValueNodeInterface|SerializationInterface|null
+     * @var ValueNodeInterface|null
      */
     protected $value;
 
     /**
-     * @return ValueNodeInterface|SerializationInterface|null
+     * @return ValueNodeInterface|null
      */
     public function getValue()
     {
@@ -23,13 +20,13 @@ trait ValueLiteralTrait
     /**
      * @return array
      */
-    public function getValueAsArray(): array
+    public function getValueAST(): array
     {
-        return null !== $this->value ? $this->value->toArray() : null;
+        return null !== $this->value ? $this->value->toAST() : null;
     }
 
     /**
-     * @param ValueNodeInterface|SerializationInterface|null $value
+     * @param ValueNodeInterface|null $value
      * @return $this
      */
     public function setValue($value)

--- a/src/Language/Node/ValueNodeInterface.php
+++ b/src/Language/Node/ValueNodeInterface.php
@@ -4,5 +4,4 @@ namespace Digia\GraphQL\Language\Node;
 
 interface ValueNodeInterface extends NodeInterface
 {
-
 }

--- a/src/Language/Node/VariableDefinitionNode.php
+++ b/src/Language/Node/VariableDefinitionNode.php
@@ -7,16 +7,12 @@ use Digia\GraphQL\Language\Location;
 class VariableDefinitionNode extends AbstractNode implements DefinitionNodeInterface
 {
     use DefaultValueTrait;
+    use TypeTrait;
 
     /**
      * @var VariableNode
      */
     protected $variable;
-
-    /**
-     * @var TypeNodeInterface
-     */
-    protected $type;
 
     /**
      * VariableDefinitionNode constructor.
@@ -48,31 +44,11 @@ class VariableDefinitionNode extends AbstractNode implements DefinitionNodeInter
     }
 
     /**
-     * @return TypeNodeInterface
+     * @return array
      */
-    public function getType(): TypeNodeInterface
+    public function getVariableAsArray(): array
     {
-        return $this->type;
-    }
-
-    /**
-     * @param VariableNode $variable
-     * @return VariableDefinitionNode
-     */
-    public function setVariable(VariableNode $variable): VariableDefinitionNode
-    {
-        $this->variable = $variable;
-        return $this;
-    }
-
-    /**
-     * @param TypeNodeInterface $type
-     * @return VariableDefinitionNode
-     */
-    public function setType(TypeNodeInterface $type): VariableDefinitionNode
-    {
-        $this->type = $type;
-        return $this;
+        return $this->variable->toArray();
     }
 
     /**
@@ -81,5 +57,18 @@ class VariableDefinitionNode extends AbstractNode implements DefinitionNodeInter
     public function __toString(): string
     {
         return (string)$this->type;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind'     => $this->kind,
+            'variable' => $this->getVariableAsArray(),
+            'type'     => $this->getTypeAsArray(),
+            'loc'      => $this->getLocationAsArray(),
+        ];
     }
 }

--- a/src/Language/Node/VariableDefinitionNode.php
+++ b/src/Language/Node/VariableDefinitionNode.php
@@ -46,9 +46,9 @@ class VariableDefinitionNode extends AbstractNode implements DefinitionNodeInter
     /**
      * @return array
      */
-    public function getVariableAsArray(): array
+    public function getVariableAST(): array
     {
-        return $this->variable->toArray();
+        return $this->variable->toAST();
     }
 
     /**
@@ -62,13 +62,13 @@ class VariableDefinitionNode extends AbstractNode implements DefinitionNodeInter
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind'     => $this->kind,
-            'variable' => $this->getVariableAsArray(),
-            'type'     => $this->getTypeAsArray(),
-            'loc'      => $this->getLocationAsArray(),
+            'variable' => $this->getVariableAST(),
+            'type'     => $this->getTypeAST(),
+            'loc'      => $this->getLocationAST(),
         ];
     }
 }

--- a/src/Language/Node/VariableDefinitionsTrait.php
+++ b/src/Language/Node/VariableDefinitionsTrait.php
@@ -2,8 +2,6 @@
 
 namespace Digia\GraphQL\Language\Node;
 
-use Digia\GraphQL\Util\SerializationInterface;
-
 trait VariableDefinitionsTrait
 {
     /**
@@ -22,10 +20,10 @@ trait VariableDefinitionsTrait
     /**
      * @return array
      */
-    public function getVariableDefinitionsAsArray(): array
+    public function getVariableDefinitionsAST(): array
     {
-        return \array_map(function (SerializationInterface $node) {
-            return $node->toArray();
+        return \array_map(function (VariableDefinitionNode $node) {
+            return $node->toAST();
         }, $this->variableDefinitions);
     }
 

--- a/src/Language/Node/VariableNode.php
+++ b/src/Language/Node/VariableNode.php
@@ -24,11 +24,11 @@ class VariableNode extends AbstractNode implements ValueNodeInterface, NameAware
     /**
      * @inheritdoc
      */
-    public function toArray(): array
+    public function toAST(): array
     {
         return [
             'kind' => $this->kind,
-            'name' => $this->getNameAsArray(),
+            'name' => $this->getNameAST(),
         ];
     }
 }

--- a/src/Language/Node/VariableNode.php
+++ b/src/Language/Node/VariableNode.php
@@ -20,4 +20,15 @@ class VariableNode extends AbstractNode implements ValueNodeInterface, NameAware
 
         $this->name = $name;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind' => $this->kind,
+            'name' => $this->getNameAsArray(),
+        ];
+    }
 }

--- a/src/Language/Visitor/AcceptsVisitorsTrait.php
+++ b/src/Language/Visitor/AcceptsVisitorsTrait.php
@@ -34,7 +34,7 @@ trait AcceptsVisitorsTrait
     protected $ancestors = [];
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $isEdited = false;
 

--- a/tests/Functional/Language/VisitorTest.php
+++ b/tests/Functional/Language/VisitorTest.php
@@ -60,7 +60,7 @@ class VisitorTest extends TestCase
     public function testAllowsForEditingOnEnter()
     {
         /** @noinspection PhpUnhandledExceptionInspection */
-        $ast = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
+        $document = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
 
         $visitor = new Visitor(
             function (NodeInterface $node): ?NodeInterface {
@@ -71,25 +71,25 @@ class VisitorTest extends TestCase
             }
         );
 
-        $editedAst = $ast->acceptVisitor($visitor);
+        $editedDocument = $document->acceptVisitor($visitor);
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->assertEquals(
             parse('{ a, b, c { a, b, c } }', ['noLocation' => true])->toArray(),
-            $ast->toArray()
+            $document->toAST()
         );
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->assertEquals(
             parse('{ a,    c { a,    c } }', ['noLocation' => true])->toArray(),
-            $editedAst->toArray()
+            $editedDocument->toAST()
         );
     }
 
     public function testAllowsForEditingOnLeave()
     {
         /** @noinspection PhpUnhandledExceptionInspection */
-        $ast = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
+        $document = parse('{ a, b, c { a, b, c } }', ['noLocation' => true]);
 
         $visitor = new Visitor(
             null,
@@ -101,18 +101,18 @@ class VisitorTest extends TestCase
             }
         );
 
-        $editedAst = $ast->acceptVisitor($visitor);
+        $editedDocument = $document->acceptVisitor($visitor);
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->assertEquals(
             parse('{ a, b, c { a, b, c } }', ['noLocation' => true])->toArray(),
-            $ast->toArray()
+            $document->toAST()
         );
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->assertEquals(
             parse('{ a,    c { a,    c } }', ['noLocation' => true])->toArray(),
-            $editedAst->toArray()
+            $editedDocument->toAST()
         );
     }
 
@@ -1185,10 +1185,10 @@ class VisitorTest extends TestCase
                     ) {
                         return $nodeBuilder->build([
                             'kind'         => NodeKindEnum::FIELD,
-                            'alias'        => $node->getAliasAsArray(),
-                            'name'         => $node->getNameAsArray(),
-                            'arguments'    => $node->getArgumentsAsArray(),
-                            'directives'   => $node->getDirectivesAsArray(),
+                            'alias'        => $node->getAliasAST(),
+                            'name'         => $node->getNameAST(),
+                            'arguments'    => $node->getArgumentsAST(),
+                            'directives'   => $node->getDirectivesAST(),
                             'selectionSet' => [
                                 'kind'   => NodeKindEnum::SELECTION_SET,
                                 'fields' => [


### PR DESCRIPTION
Refactor nodes to use `toAST` methods instead of `toArray` to make it easier to understand that the array form is the actual Abstract Syntax Tree. Also, I added missing serialization methods for some nodes and removed the method from the abstract class altogether.