### PR TITLE
Add a SourceBuilderInterface along with two basic implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ this example we use that SDL to build an executable schema and use it to query f
 of that query is an associative array with a structure that resembles the query we ran.
 
 ```php
+use Digia\GraphQL\Language\FileSourceBuilder;
 use function Digia\GraphQL\buildSchema;
 use function Digia\GraphQL\graphql;
 
-$source = \file_get_contents(__DIR__ . '/star-wars.graphqls');
+$sourceBuilder = new FileSourceBuilder(__DIR__ . '/star-wars.graphqls');
 
-$schema = buildSchema($source, [
+$schema = buildSchema($sourceBuilder->build(), [
     'Query' => [
         'hero' => function ($rootValue, $arguments) {
             return getHero($arguments['episode'] ?? null);
@@ -127,9 +128,11 @@ SDL you need to call the `buildSchema` function.
  
 The `buildSchema` function takes three arguments:
 
-- `$source` The schema definition (SDL) as a string
+- `$source` The schema definition (SDL) as a `Source` instance
 - `$resolverRegistry` An associative array or a `ResolverRegistry` instance that contains all resolvers
 - `$options` The options for building the schema, which also includes custom types and directives
+
+To create the `Source` instance you can use the provided `FileSourceBuilder` or `MultiFileSourceBuilder` classes.
 
 ### Resolver registry
 

--- a/src/Error/FileNotFoundException.php
+++ b/src/Error/FileNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Digia\GraphQL\Error;
+
+/**
+ * Class FileNotFoundException
+ * @package Digia\GraphQL\Error
+ */
+class FileNotFoundException extends AbstractException
+{
+
+}

--- a/src/Language/FileSourceBuilder.php
+++ b/src/Language/FileSourceBuilder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Digia\GraphQL\Language;
+
+use Digia\GraphQL\Error\FileNotFoundException;
+use Digia\GraphQL\Error\InvariantException;
+
+/**
+ * Class FileSourceBuilder
+ * @package Digia\GraphQL\Language
+ */
+class FileSourceBuilder implements SourceBuilderInterface
+{
+    /**
+     * @var string
+     */
+    private $filePath;
+
+    /**
+     * FileSourceBuilder constructor.
+     * @param string $filePath
+     */
+    public function __construct(string $filePath)
+    {
+        $this->filePath = $filePath;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws FileNotFoundException
+     * @throws InvariantException
+     */
+    public function build(): Source
+    {
+        if (!\file_exists($this->filePath) || !\is_readable($this->filePath)) {
+            throw new FileNotFoundException(sprintf('The file %s cannot be found or is not readable', $this->filePath));
+        }
+
+        return new Source(\file_get_contents($this->filePath));
+    }
+}

--- a/src/Language/MultiFileSourceBuilder.php
+++ b/src/Language/MultiFileSourceBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Digia\GraphQL\Language;
+
+use Digia\GraphQL\Error\FileNotFoundException;
+use Digia\GraphQL\Error\InvariantException;
+
+/**
+ * Class MultiFileSourceBuilder
+ * @package Digia\GraphQL\Language
+ */
+class MultiFileSourceBuilder implements SourceBuilderInterface
+{
+
+    /**
+     * @var string[]
+     */
+    private $filePaths;
+
+    /**
+     * MultiFileSourceBuilder constructor.
+     * @param string[] $filePaths
+     */
+    public function __construct(array $filePaths)
+    {
+        $this->filePaths = $filePaths;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws FileNotFoundException
+     * @throws InvariantException
+     */
+    public function build(): Source
+    {
+        $combinedSource = '';
+
+        foreach ($this->filePaths as $filePath) {
+            if (!\file_exists($filePath) || !\is_readable($filePath)) {
+                throw new FileNotFoundException(sprintf('The file %s cannot be found or is not readable', $filePath));
+            }
+
+            $combinedSource .= \file_get_contents($filePath);
+        }
+
+        return new Source($combinedSource);
+    }
+}

--- a/src/Language/SourceBuilderInterface.php
+++ b/src/Language/SourceBuilderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Digia\GraphQL\Language;
+
+/**
+ * Interface SourceBuilderInterface
+ * @package Digia\GraphQL\Language
+ */
+interface SourceBuilderInterface
+{
+
+    /**
+     * @return Source
+     */
+    public function build(): Source;
+}

--- a/tests/Functional/Language/FileSourceBuilderTest.php
+++ b/tests/Functional/Language/FileSourceBuilderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Digia\GraphQL\Test\Functional\Language;
+
+use Digia\GraphQL\Language\FileSourceBuilder;
+use Digia\GraphQL\Test\TestCase;
+
+/**
+ * Class FileSourceBuilderTest
+ * @package Digia\GraphQL\Test\Functional\Language
+ */
+class FileSourceBuilderTest extends TestCase
+{
+
+    /**
+     * @expectedException \Digia\GraphQL\Error\FileNotFoundException
+     * @throws \Digia\GraphQL\Error\InvariantException
+     */
+    public function testFileNotFound(): void
+    {
+        $builder = new FileSourceBuilder('/not/existing/file.graphqls');
+
+        $builder->build();
+    }
+
+    /**
+     * @throws \Digia\GraphQL\Error\InvariantException
+     * @throws \Digia\GraphQL\Error\FileNotFoundException
+     */
+    public function testSuccess(): void
+    {
+        $builder = new FileSourceBuilder(__DIR__ . '/schema-kitchen-sink.graphqls');
+
+        $source = $builder->build();
+
+        $this->assertGreaterThan(0, $source->getBodyLength());
+    }
+}

--- a/tests/Functional/Language/MultiFileSourceBuilderTest.php
+++ b/tests/Functional/Language/MultiFileSourceBuilderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Digia\GraphQL\Test\Functional\Language;
+
+use Digia\GraphQL\Language\MultiFileSourceBuilder;
+use Digia\GraphQL\Test\TestCase;
+
+/**
+ * Class MultiFileSourceBuilderTest
+ * @package Digia\GraphQL\Test\Functional\Language
+ */
+class MultiFileSourceBuilderTest extends TestCase
+{
+
+    /**
+     * @throws \Digia\GraphQL\Error\InvariantException
+     * @throws \Digia\GraphQL\Error\FileNotFoundException
+     */
+    public function testBuildSource(): void
+    {
+        $builder = new MultiFileSourceBuilder([
+            __DIR__ . '/schema-kitchen-sink.graphqls',
+            __DIR__ . '/../starWars.graphqls',
+        ]);
+
+        $source = $builder->build();
+
+        $this->assertEquals(3747, $source->getBodyLength());
+    }
+}


### PR DESCRIPTION
The FileSourceBuilder just does \file_get_contents() on a file, so it's not that useful unless we change the API to accept only Source and not string.

The DirectorySourceBuilder is more interesting since it allows people to split their giant SDL files into multiple logic units (e.g. one for Relay, one for common sorting/ordering stuff, etc.).