### PR TITLE
Fix the incomplete FieldOnCorrectTypeRuleTest testcase

### DIFF
--- a/tests/Functional/Validation/Rule/FieldOnCorrectTypeRuleTest.php
+++ b/tests/Functional/Validation/Rule/FieldOnCorrectTypeRuleTest.php
@@ -245,10 +245,6 @@ class FieldOnCorrectTypeRuleTest extends RuleTestCase
 
     public function testDefinedOnImplementorsQueriedOnUnion()
     {
-        $this->markTestIncomplete(
-            'POTENTIAL BUG: Test taken from the reference implementation goes against all logic because Cat is defined before Dog.'
-        );
-
         $this->expectFailsRule(
             $this->rule,
             dedent('

--- a/tests/Functional/Validation/harness.php
+++ b/tests/Functional/Validation/harness.php
@@ -158,7 +158,7 @@ function CatOrDog(): UnionType
     return $instance ??
         $instance = newUnionType([
             'name'  => 'CatOrDog',
-            'types' => [Cat(), Dog()],
+            'types' => [Dog(), Cat()],
         ]);
 }
 


### PR DESCRIPTION
The CatOrDog union type definition in harness.php was wrong, in the reference implementation it is indeed "Dog, Cat", not "Cat, Dog", even though the union name is "CatOrDog"