### PR TITLE
String source builder

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -121,12 +121,12 @@ class GraphQL
     }
 
     /**
-     * @param string|Source                   $source
+     * @param Source                          $source
      * @param array|ResolverRegistryInterface $resolverRegistry
      * @param array                           $options
      * @return Schema
      */
-    public static function buildSchema($source, $resolverRegistry, array $options = []): Schema
+    public static function buildSchema(Source $source, $resolverRegistry, array $options = []): Schema
     {
         return static::make(SchemaBuilderInterface::class)
             ->build(
@@ -140,14 +140,14 @@ class GraphQL
 
     /**
      * @param Schema                          $schema
-     * @param string|Source                   $source
+     * @param Source                          $source
      * @param array|ResolverRegistryInterface $resolverRegistry
      * @param array                           $options
      * @return Schema
      */
     public static function extendSchema(
         Schema $schema,
-        $source,
+        Source $source,
         $resolverRegistry,
         array $options = []
     ): Schema {
@@ -175,11 +175,11 @@ class GraphQL
     }
 
     /**
-     * @param string|Source $source
-     * @param array         $options
+     * @param Source $source
+     * @param array  $options
      * @return DocumentNode
      */
-    public static function parse($source, array $options = []): DocumentNode
+    public static function parse(Source $source, array $options = []): DocumentNode
     {
         /** @var ParserInterface $parser */
         $parser = static::make(ParserInterface::class);
@@ -188,11 +188,11 @@ class GraphQL
     }
 
     /**
-     * @param string|Source $source
-     * @param array         $options
+     * @param Source $source
+     * @param array  $options
      * @return ValueNodeInterface
      */
-    public static function parseValue($source, array $options = []): ValueNodeInterface
+    public static function parseValue(Source $source, array $options = []): ValueNodeInterface
     {
         /** @var ParserInterface $parser */
         $parser = static::make(ParserInterface::class);
@@ -201,11 +201,11 @@ class GraphQL
     }
 
     /**
-     * @param string|Source $source
-     * @param array         $options
+     * @param Source $source
+     * @param array  $options
      * @return TypeNodeInterface
      */
-    public static function parseType($source, array $options = []): TypeNodeInterface
+    public static function parseType(Source $source, array $options = []): TypeNodeInterface
     {
         /** @var ParserInterface $parser */
         $parser = static::make(ParserInterface::class);

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -46,9 +46,9 @@ use Digia\GraphQL\Language\Node\SchemaDefinitionNode;
 use Digia\GraphQL\Language\Node\SchemaExtensionNode;
 use Digia\GraphQL\Language\Node\SelectionSetNode;
 use Digia\GraphQL\Language\Node\StringValueNode;
+use Digia\GraphQL\Language\Node\TypeNodeInterface;
 use Digia\GraphQL\Language\Node\TypeSystemDefinitionNodeInterface;
 use Digia\GraphQL\Language\Node\TypeSystemExtensionNodeInterface;
-use Digia\GraphQL\Language\Node\TypeNodeInterface;
 use Digia\GraphQL\Language\Node\UnionTypeDefinitionNode;
 use Digia\GraphQL\Language\Node\UnionTypeExtensionNode;
 use Digia\GraphQL\Language\Node\ValueNodeInterface;
@@ -97,7 +97,7 @@ class Parser implements ParserInterface
      * @throws \ReflectionException
      * @throws InvariantException
      */
-    public function parse($source, array $options = []): DocumentNode
+    public function parse(Source $source, array $options = []): DocumentNode
     {
         $this->lexer = $this->createLexer($source, $options);
 
@@ -105,14 +105,13 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param callable      $lexCallback
-     * @param Source|string $source
-     * @param array         $options
+     * @param callable $lexCallback
+     * @param Source   $source
+     * @param array    $options
      * @return NodeInterface
-     * @throws InvariantException
      * @throws SyntaxErrorException
      */
-    protected function parsePartial(callable $lexCallback, $source, array $options = []): NodeInterface
+    protected function parsePartial(callable $lexCallback, Source $source, array $options = []): NodeInterface
     {
         $this->lexer = $this->createLexer($source, $options);
 
@@ -1629,14 +1628,13 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param string|Source $source
-     * @param array         $options
+     * @param Source $source
+     * @param array  $options
      * @return LexerInterface
-     * @throws InvariantException
      */
     protected function createLexer($source, array $options): LexerInterface
     {
-        return new Lexer($source instanceof Source ? $source : new Source($source), $options);
+        return new Lexer($source, $options);
     }
 
     /**

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -116,7 +116,7 @@ class Parser implements ParserInterface
         $this->lexer = $this->createLexer($source, $options);
 
         $this->expect(TokenKindEnum::SOF);
-        $node = $lexCallback($source, $options);
+        $node = $lexCallback();
         $this->expect(TokenKindEnum::EOF);
 
         return $node;
@@ -750,7 +750,7 @@ class Parser implements ParserInterface
      * @return DirectiveNode
      * @throws SyntaxErrorException
      */
-    protected function lexDirective(bool $isConst): DirectiveNode
+    protected function lexDirective(bool $isConst = false): DirectiveNode
     {
         $start = $this->lexer->getToken();
 

--- a/src/Language/ParserInterface.php
+++ b/src/Language/ParserInterface.php
@@ -46,9 +46,9 @@ interface ParserInterface
     /**
      * Given a GraphQL source, parses it into a Document.
      *
-     * @param Source|string $source
-     * @param array         $options
+     * @param Source $source
+     * @param array  $options
      * @return DocumentNode
      */
-    public function parse($source, array $options = []): DocumentNode;
+    public function parse(Source $source, array $options = []): DocumentNode;
 }

--- a/src/Language/StringSourceBuilder.php
+++ b/src/Language/StringSourceBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Digia\GraphQL\Language;
+
+class StringSourceBuilder implements SourceBuilderInterface
+{
+
+    /**
+     * @var string
+     */
+    private $body;
+
+    /**
+     * StringSourceBuilder constructor.
+     * @param string $body
+     */
+    public function __construct(string $body)
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function build(): Source
+    {
+        return new Source($this->body);
+    }
+}

--- a/src/api.php
+++ b/src/api.php
@@ -12,6 +12,7 @@ use Digia\GraphQL\Language\Node\NodeInterface;
 use Digia\GraphQL\Language\Node\TypeNodeInterface;
 use Digia\GraphQL\Language\Node\ValueNodeInterface;
 use Digia\GraphQL\Language\Source;
+use Digia\GraphQL\Language\StringSourceBuilder;
 use Digia\GraphQL\Schema\Resolver\ResolverRegistryInterface;
 use Digia\GraphQL\Schema\Schema;
 
@@ -24,6 +25,10 @@ use Digia\GraphQL\Schema\Schema;
  */
 function buildSchema($source, $resolverRegistry = [], array $options = []): Schema
 {
+    if (\is_string($source)) {
+        $source = (new StringSourceBuilder($source))->build();
+    }
+    
     return GraphQL::buildSchema($source, $resolverRegistry, $options);
 }
 
@@ -37,6 +42,10 @@ function buildSchema($source, $resolverRegistry = [], array $options = []): Sche
  */
 function extendSchema(Schema $schema, $source, $resolverRegistry = [], array $options = []): Schema
 {
+    if (\is_string($source)) {
+        $source = (new StringSourceBuilder($source))->build();
+    }
+    
     return GraphQL::extendSchema($schema, $source, $resolverRegistry, $options);
 }
 
@@ -58,6 +67,10 @@ function validateSchema(Schema $schema): array
  */
 function parse($source, array $options = []): DocumentNode
 {
+    if (\is_string($source)) {
+        $source = (new StringSourceBuilder($source))->build();
+    }
+    
     return GraphQL::parse($source, $options);
 }
 
@@ -70,6 +83,10 @@ function parse($source, array $options = []): DocumentNode
  */
 function parseValue($source, array $options = []): ValueNodeInterface
 {
+    if (\is_string($source)) {
+        $source = (new StringSourceBuilder($source))->build();
+    }
+    
     return GraphQL::parseValue($source, $options);
 }
 
@@ -82,6 +99,10 @@ function parseValue($source, array $options = []): ValueNodeInterface
  */
 function parseType($source, array $options = []): TypeNodeInterface
 {
+    if (\is_string($source)) {
+        $source = (new StringSourceBuilder($source))->build();
+    }
+    
     return GraphQL::parseType($source, $options);
 }
 

--- a/tests/Functional/Language/ParserTest.php
+++ b/tests/Functional/Language/ParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Test\Functional\Language;
 
+use Digia\GraphQL\Error\InvariantException;
 use Digia\GraphQL\Error\SyntaxErrorException;
 use Digia\GraphQL\GraphQL;
 use Digia\GraphQL\Language\Node\ArgumentNode;
@@ -12,6 +13,7 @@ use Digia\GraphQL\Language\Node\OperationDefinitionNode;
 use Digia\GraphQL\Language\Node\VariableDefinitionNode;
 use Digia\GraphQL\Language\Node\VariableNode;
 use Digia\GraphQL\Language\ParserInterface;
+use Digia\GraphQL\Language\Source;
 use Digia\GraphQL\Test\TestCase;
 use function Digia\GraphQL\Language\dedent;
 use function Digia\GraphQL\parse;
@@ -22,26 +24,29 @@ use function Digia\GraphQL\Test\readFileContents;
 class ParserTest extends TestCase
 {
 
+    /**
+     * @throws InvariantException
+     */
     public function testParsePartial()
     {
         /** @var ParserInterface $parser */
         $parser = GraphQL::make(ParserInterface::class);
 
         /** @var NameNode $nameNode */
-        $nameNode = $parser->parseName('foo');
+        $nameNode = $parser->parseName(new Source('foo'));
 
         $this->assertInstanceOf(NameNode::class, $nameNode);
         $this->assertEquals('foo', $nameNode->getValue());
 
         /** @var OperationDefinitionNode $operationDefinition */
-        $operationDefinition = $parser->parseOperationDefinition('query FooQuery { foo }');
+        $operationDefinition = $parser->parseOperationDefinition(new Source('query FooQuery { foo }'));
 
         $this->assertInstanceOf(OperationDefinitionNode::class, $operationDefinition);
         $this->assertEquals('query', $operationDefinition->getOperation());
         $this->assertEquals('FooQuery', $operationDefinition->getNameValue());
 
         /** @var VariableDefinitionNode $variableDefinitionNode */
-        $variableDefinitionNode = $parser->parseVariableDefinition('$foo: String = "bar"');
+        $variableDefinitionNode = $parser->parseVariableDefinition(new Source('$foo: String = "bar"'));
 
         $this->assertInstanceOf(VariableDefinitionNode::class, $variableDefinitionNode);
         $this->assertEquals('foo', $variableDefinitionNode->getVariable()->getNameValue());
@@ -51,19 +56,19 @@ class ParserTest extends TestCase
         $this->assertEquals('bar', $variableDefinitionNode->getDefaultValue()->getValue());
 
         /** @var VariableNode $variableNode */
-        $variableNode = $parser->parseVariable('$foo');
+        $variableNode = $parser->parseVariable(new Source('$foo'));
 
         $this->assertInstanceOf(VariableNode::class, $variableNode);
         $this->assertEquals('foo', $variableNode->getNameValue());
 
         /** @var ArgumentNode $argumentNode */
-        $argumentNode = $parser->parseArgument('foo: String');
+        $argumentNode = $parser->parseArgument(new Source('foo: String'));
 
         $this->assertInstanceOf(ArgumentNode::class, $argumentNode);
         $this->assertEquals('foo', $argumentNode->getNameValue());
 
         /** @var DirectiveNode $directiveNode */
-        $directiveNode = $parser->parseDirective('@foo(bar: String, baz: Int)');
+        $directiveNode = $parser->parseDirective(new Source('@foo(bar: String, baz: Int)'));
         $directiveArgs = $directiveNode->getArguments();
 
         $this->assertInstanceOf(DirectiveNode::class, $directiveNode);

--- a/tests/Functional/Language/StringSourceBuilderTest.php
+++ b/tests/Functional/Language/StringSourceBuilderTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Digia\GraphQL\Test\Functional\Language;
+
+use Digia\GraphQL\Language\StringSourceBuilder;
+use Digia\GraphQL\Test\TestCase;
+
+class StringSourceBuilderTest extends TestCase
+{
+
+    /**
+     * @throws \Digia\GraphQL\Error\InvariantException
+     */
+    public function testBuild(): void
+    {
+        $body = \file_get_contents(__DIR__ . '/schema-kitchen-sink.graphqls');
+
+        $builder = new StringSourceBuilder($body);
+        $source  = $builder->build();
+
+        $this->assertGreaterThan(0, $source->getBodyLength());
+    }
+}

--- a/tests/Unit/Language/LexerTest.php
+++ b/tests/Unit/Language/LexerTest.php
@@ -553,8 +553,10 @@ EOD;
     }
 
     /**
-     * @param Source|string $source
+     * @param string|Source $source
+     * @param array         $options
      * @return LexerInterface
+     * @throws \Digia\GraphQL\Error\InvariantException
      */
     private function getLexer($source, array $options = []): LexerInterface
     {


### PR DESCRIPTION
String source builder, stop passing around both strings and Source objects.

This way we can use static type-hinting, which in this case unearthed a bug with how lex methods are called in the parser.
