### PR TITLE
Type resolver

### DIFF
--- a/src/Schema/Resolver/AbstractFieldResolver.php
+++ b/src/Schema/Resolver/AbstractFieldResolver.php
@@ -4,8 +4,10 @@ namespace Digia\GraphQL\Schema\Resolver;
 
 use Digia\GraphQL\Execution\ResolveInfo;
 
-abstract class AbstractResolver implements ResolverInterface
+abstract class AbstractFieldResolver implements ResolverInterface
 {
+    use ResolverTrait;
+
     /**
      * @param mixed            $rootValue
      * @param array            $arguments
@@ -31,35 +33,5 @@ abstract class AbstractResolver implements ResolverInterface
         return function ($rootValue, array $arguments, $context = null, ?ResolveInfo $info = null) {
             return $this->resolve($rootValue, $arguments, $context, $info);
         };
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getTypeResolver(): ?callable
-    {
-        return function ($rootValue, $context = null, ?ResolveInfo $info = null) {
-            return $this->resolveType($rootValue, $context, $info);
-        };
-    }
-
-    /**
-     * @param mixed            $rootValue
-     * @param mixed            $context
-     * @param ResolveInfo|null $info
-     * @return callable|null
-     */
-    public function resolveType($rootValue, $context = null, ?ResolveInfo $info = null): ?callable
-    {
-        // Override this method when your resolver returns an interface or an union type.
-        return null;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getMiddleware(): ?array
-    {
-        return null;
     }
 }

--- a/src/Schema/Resolver/AbstractTypeResolver.php
+++ b/src/Schema/Resolver/AbstractTypeResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Digia\GraphQL\Schema\Resolver;
+
+abstract class AbstractTypeResolver implements ResolverCollectionInterface
+{
+    use ResolverTrait;
+
+    /**
+     * @return callable|null
+     */
+    public function getResolveCallback(): ?callable
+    {
+        return function (string $fieldName) {
+            return $this->getResolver($fieldName);
+        };
+    }
+
+    /**
+     * @param string $fieldName
+     * @return callable|null
+     */
+    public function getResolver(string $fieldName): ?callable
+    {
+        $resolveMethod = 'resolve' . \ucfirst($fieldName);
+
+        if (\method_exists($this, $resolveMethod)) {
+            return [$this, $resolveMethod];
+        }
+
+        return null;
+    }
+}

--- a/src/Schema/Resolver/ResolverCollectionInterface.php
+++ b/src/Schema/Resolver/ResolverCollectionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Digia\GraphQL\Schema\Resolver;
+
+interface ResolverCollectionInterface extends ResolverInterface
+{
+    /**
+     * @param string $fieldName
+     * @return callable|null
+     */
+    public function getResolver(string $fieldName): ?callable;
+}

--- a/src/Schema/Resolver/ResolverMap.php
+++ b/src/Schema/Resolver/ResolverMap.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Schema\Resolver;
 
-class ResolverCollection implements ResolverInterface
+class ResolverMap implements ResolverCollectionInterface
 {
     protected const TYPE_RESOLVER_KEY = '__resolveType';
 
@@ -43,7 +43,7 @@ class ResolverCollection implements ResolverInterface
      */
     public function getResolveCallback(): ?callable
     {
-        return function ($fieldName) {
+        return function (string $fieldName) {
             $resolver = $this->getResolver($fieldName);
 
             return $resolver instanceof ResolverInterface
@@ -75,7 +75,7 @@ class ResolverCollection implements ResolverInterface
     {
         foreach ($resolvers as $typeName => $resolver) {
             if (\is_array($resolver)) {
-                $resolver = new ResolverCollection($resolver);
+                $resolver = new ResolverMap($resolver);
             }
 
             $this->addResolver($typeName, $resolver);

--- a/src/Schema/Resolver/ResolverRegistry.php
+++ b/src/Schema/Resolver/ResolverRegistry.php
@@ -43,7 +43,7 @@ class ResolverRegistry implements ResolverRegistryInterface
     {
         $resolver = $this->getResolver($typeName);
 
-        $resolver = $resolver instanceof ResolverCollection
+        $resolver = $resolver instanceof ResolverCollectionInterface
             ? $resolver->getResolver($fieldName)
             : $resolver;
 
@@ -95,7 +95,7 @@ class ResolverRegistry implements ResolverRegistryInterface
     {
         foreach ($resolvers as $typeName => $resolver) {
             if (\is_array($resolver)) {
-                $resolver = new ResolverCollection($resolver);
+                $resolver = new ResolverMap($resolver);
             }
 
             $this->register($typeName, $resolver);

--- a/src/Schema/Resolver/ResolverTrait.php
+++ b/src/Schema/Resolver/ResolverTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Digia\GraphQL\Schema\Resolver;
+
+use Digia\GraphQL\Execution\ResolveInfo;
+
+trait ResolverTrait
+{
+    /**
+     * @return callable|null
+     */
+    public function getTypeResolver(): ?callable
+    {
+        return function ($rootValue, $context = null, ?ResolveInfo $info = null) {
+            return $this->resolveType($rootValue, $context, $info);
+        };
+    }
+
+    /**
+     * @param mixed            $rootValue
+     * @param mixed            $context
+     * @param ResolveInfo|null $info
+     * @return callable|null
+     */
+    public function resolveType($rootValue, $context = null, ?ResolveInfo $info = null): ?callable
+    {
+        // Override this method when your resolver returns an interface or an union type.
+        return null;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getMiddleware(): ?array
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Re-introduce type resolvers because this will allow developers to apply middleware on the type-level in addition to field-level and global-level.
