### PR TITLE
Visitor info

### DIFF
--- a/src/Language/Node/NodeInterface.php
+++ b/src/Language/Node/NodeInterface.php
@@ -4,6 +4,7 @@ namespace Digia\GraphQL\Language\Node;
 
 use Digia\GraphQL\Language\Location;
 use Digia\GraphQL\Language\Visitor\VisitorBreak;
+use Digia\GraphQL\Language\Visitor\VisitorInfo;
 use Digia\GraphQL\Language\Visitor\VisitorInterface;
 
 interface NodeInterface
@@ -35,32 +36,27 @@ interface NodeInterface
     public function toJSON(): string;
 
     /**
-     * @param VisitorInterface   $visitor
-     * @param string|int         $key
-     * @param NodeInterface|null $parent
-     * @param array              $path
-     * @param array              $ancestors
+     * @param VisitorInfo $visitorInfo
      * @return NodeInterface|null
-     * @throws VisitorBreak
      */
-    public function acceptVisitor(
-        VisitorInterface $visitor,
-        $key = null,
-        ?NodeInterface $parent = null,
-        array $path = [],
-        array $ancestors = []
-    ): ?NodeInterface;
+    public function acceptVisitor(VisitorInfo $visitorInfo): ?NodeInterface;
 
     /**
-     * @return NodeInterface|null
+     * @return VisitorInfo|null
      */
-    public function getAncestor(int $depth = 1): ?NodeInterface;
+    public function getVisitorInfo(): ?VisitorInfo;
 
     /**
      * @param NodeInterface $node
      * @return bool
      */
     public function determineIsEdited(NodeInterface $node): bool;
+
+    /**
+     * @param int $depth
+     * @return NodeInterface|null
+     */
+    public function getAncestor(int $depth = 1): ?NodeInterface;
 
     /**
      * @return bool

--- a/src/Language/Visitor/VisitorInfo.php
+++ b/src/Language/Visitor/VisitorInfo.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Digia\GraphQL\Language\Visitor;
+
+use Digia\GraphQL\Language\Node\NodeInterface;
+
+class VisitorInfo
+{
+    /**
+     * @var VisitorInterface
+     */
+    protected $visitor;
+
+    /**
+     * @var string|int|null
+     */
+    protected $key;
+
+    /**
+     * @var NodeInterface|null
+     */
+    protected $parent;
+
+    /**
+     * @var array
+     */
+    protected $path;
+
+    /**
+     * @var array
+     */
+    protected $ancestors;
+
+    /**
+     * VisitorInfo constructor.
+     * @param VisitorInterface   $visitor
+     * @param int|null|string    $key
+     * @param NodeInterface|null $parent
+     * @param array              $path
+     * @param array              $ancestors
+     */
+    public function __construct(
+        VisitorInterface $visitor,
+        $key = null,
+        ?NodeInterface $parent = null,
+        array $path = [],
+        array $ancestors = []
+    ) {
+        $this->visitor   = $visitor;
+        $this->key       = $key;
+        $this->parent    = $parent;
+        $this->path      = $path;
+        $this->ancestors = $ancestors;
+    }
+
+    /**
+     * Appends a key to the path.
+     * @param string $key
+     */
+    public function addOneToPath(string $key)
+    {
+        $this->path[] = $key;
+    }
+
+    /**
+     * Removes the last item from the path.
+     */
+    public function removeOneFromPath()
+    {
+        $this->path = \array_slice($this->path, 0, -1);
+    }
+
+    /**
+     * Adds an ancestor.
+     * @param NodeInterface $node
+     */
+    public function addAncestor(NodeInterface $node)
+    {
+        $this->ancestors[] = $node;
+    }
+
+    /**
+     *  Removes the last ancestor.
+     */
+    public function removeAncestor()
+    {
+        $this->ancestors = \array_slice($this->ancestors, 0, -1);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAncestor(int $depth = 1): ?NodeInterface
+    {
+        if (empty($this->ancestors)) {
+            return null;
+        }
+
+        $index = \count($this->ancestors) - $depth;
+
+        return $this->ancestors[$index] ?? null;
+    }
+
+    /**
+     * @return VisitorInterface
+     */
+    public function getVisitor(): VisitorInterface
+    {
+        return $this->visitor;
+    }
+
+    /**
+     * @return int|null|string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return NodeInterface|null
+     */
+    public function getParent(): ?NodeInterface
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPath(): array
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAncestors(): array
+    {
+        return $this->ancestors;
+    }
+}

--- a/src/Util/NodeComparator.php
+++ b/src/Util/NodeComparator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Digia\GraphQL\Util;
+
+use Digia\GraphQL\Language\Node\NodeInterface;
+
+class NodeComparator
+{
+    /**
+     * @param NodeInterface $node
+     * @param NodeInterface $other
+     * @return bool
+     */
+    public static function compare(NodeInterface $node, NodeInterface $other): bool
+    {
+        return $node->toJSON() === $other->toJSON();
+    }
+}

--- a/src/Validation/ValidationContext.php
+++ b/src/Validation/ValidationContext.php
@@ -13,6 +13,7 @@ use Digia\GraphQL\Language\Node\VariableDefinitionNode;
 use Digia\GraphQL\Language\Node\VariableNode;
 use Digia\GraphQL\Language\Visitor\TypeInfoVisitor;
 use Digia\GraphQL\Language\Visitor\Visitor;
+use Digia\GraphQL\Language\Visitor\VisitorInfo;
 use Digia\GraphQL\Language\Visitor\VisitorResult;
 use Digia\GraphQL\Schema\Schema;
 use Digia\GraphQL\Type\Definition\Argument;
@@ -257,7 +258,7 @@ class ValidationContext implements ValidationContextInterface
 
             $visitor = new TypeInfoVisitor($typeInfo, new Visitor($enterCallback));
 
-            $node->acceptVisitor($visitor);
+            $node->acceptVisitor(new VisitorInfo($visitor));
 
             $this->variableUsages[(string)$node] = $usages;
         }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -5,6 +5,7 @@ namespace Digia\GraphQL\Validation;
 use Digia\GraphQL\Language\Node\DocumentNode;
 use Digia\GraphQL\Language\Visitor\ParallelVisitor;
 use Digia\GraphQL\Language\Visitor\TypeInfoVisitor;
+use Digia\GraphQL\Language\Visitor\VisitorInfo;
 use Digia\GraphQL\Schema\Schema;
 use Digia\GraphQL\Schema\Validation\SchemaValidatorInterface;
 use Digia\GraphQL\Util\TypeInfo;
@@ -50,7 +51,8 @@ class Validator implements ValidatorInterface
         $visitor = new TypeInfoVisitor($typeInfo, new ParallelVisitor($visitors));
 
         // Visit the whole document with each instance of all provided rules.
-        $document->acceptVisitor($visitor);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $document->acceptVisitor(new VisitorInfo($visitor));
 
         return $context->getErrors();
     }

--- a/tests/Functional/Language/VisitorTest.php
+++ b/tests/Functional/Language/VisitorTest.php
@@ -13,6 +13,7 @@ use Digia\GraphQL\Language\Visitor\ParallelVisitor;
 use Digia\GraphQL\Language\Visitor\TypeInfoVisitor;
 use Digia\GraphQL\Language\Visitor\Visitor;
 use Digia\GraphQL\Language\Visitor\VisitorBreak;
+use Digia\GraphQL\Language\Visitor\VisitorInfo;
 use Digia\GraphQL\Language\Visitor\VisitorResult;
 use Digia\GraphQL\Test\TestCase;
 use Digia\GraphQL\Type\Definition\CompositeTypeInterface;
@@ -33,18 +34,19 @@ class VisitorTest extends TestCase
 
         $visitor = new Visitor(
             function (NodeInterface $node) use (&$visited): VisitorResult {
-                $visited[] = ['enter', array_slice($node->getPath(), 0)];
+                $visited[] = ['enter', array_slice($node->getVisitorInfo()->getPath(), 0)];
 
                 return new VisitorResult($node);
             },
             function (NodeInterface $node) use (&$visited): VisitorResult {
-                $visited[] = ['leave', array_slice($node->getPath(), 0)];
+                $visited[] = ['leave', array_slice($node->getVisitorInfo()->getPath(), 0)];
 
                 return new VisitorResult($node);
             }
         );
 
-        $ast->acceptVisitor($visitor);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $ast->acceptVisitor(new VisitorInfo($visitor));
 
         $this->assertEquals([
             ['enter', []],
@@ -75,7 +77,8 @@ class VisitorTest extends TestCase
             }
         );
 
-        $editedDocument = $document->acceptVisitor($visitor);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $editedDocument = $document->acceptVisitor(new VisitorInfo($visitor));
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->assertEquals(
@@ -106,7 +109,8 @@ class VisitorTest extends TestCase
             }
         );
 
-        $editedDocument = $document->acceptVisitor($visitor);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $editedDocument = $document->acceptVisitor(new VisitorInfo($visitor));
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $this->assertEquals(
@@ -151,7 +155,8 @@ class VisitorTest extends TestCase
             }
         );
 
-        $ast->acceptVisitor($visitor);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $ast->acceptVisitor(new VisitorInfo($visitor));
 
         $this->assertTrue($didVisitEditedNode);
     }
@@ -180,7 +185,8 @@ class VisitorTest extends TestCase
             }
         );
 
-        $ast->acceptVisitor($visitor);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $ast->acceptVisitor(new VisitorInfo($visitor));
 
         $this->assertEquals([
             ['enter', 'Document', null],
@@ -226,7 +232,7 @@ class VisitorTest extends TestCase
         );
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -272,7 +278,7 @@ class VisitorTest extends TestCase
         );
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -319,7 +325,7 @@ class VisitorTest extends TestCase
         );
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -356,7 +362,7 @@ class VisitorTest extends TestCase
         );
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -403,21 +409,23 @@ class VisitorTest extends TestCase
 
         $visitor = new Visitor(
             function (NodeInterface $node) use (&$visited): VisitorResult {
-                $parent    = $node->getParent();
-                $visited[] = ['enter', $node->getKind(), $node->getKey(), $parent ? $parent->getKind() : null];
+                $key       = $node->getVisitorInfo()->getKey();
+                $parent    = $node->getVisitorInfo()->getParent();
+                $visited[] = ['enter', $node->getKind(), $key, $parent ? $parent->getKind() : null];
 
                 return new VisitorResult($node);
             },
             function (NodeInterface $node) use (&$visited): VisitorResult {
-                $parent    = $node->getParent();
-                $visited[] = ['leave', $node->getKind(), $node->getKey(), $parent ? $parent->getKind() : null];
+                $key       = $node->getVisitorInfo()->getKey();
+                $parent    = $node->getVisitorInfo()->getParent();
+                $visited[] = ['leave', $node->getKind(), $key, $parent ? $parent->getKind() : null];
 
                 return new VisitorResult($node);
             }
         );
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -762,7 +770,7 @@ class VisitorTest extends TestCase
         ]);
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -848,7 +856,7 @@ class VisitorTest extends TestCase
         ]);
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -917,7 +925,7 @@ class VisitorTest extends TestCase
         ]);
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -965,7 +973,7 @@ class VisitorTest extends TestCase
         ]);
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -1050,7 +1058,7 @@ class VisitorTest extends TestCase
         ]);
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -1123,7 +1131,7 @@ class VisitorTest extends TestCase
         );
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 
@@ -1242,7 +1250,7 @@ class VisitorTest extends TestCase
         );
 
         try {
-            $ast->acceptVisitor($visitor);
+            $ast->acceptVisitor(new VisitorInfo($visitor));
         } catch (VisitorBreak $e) {
         }
 

--- a/tests/Unit/Util/NodeComparatorTest.php
+++ b/tests/Unit/Util/NodeComparatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Digia\GraphQL\Test\Unit\Util;
+
+use Digia\GraphQL\GraphQL;
+use Digia\GraphQL\Language\Node\NodeKindEnum;
+use Digia\GraphQL\Language\NodeBuilderInterface;
+use Digia\GraphQL\Test\TestCase;
+use Digia\GraphQL\Util\NodeComparator;
+
+class NodeComparatorTest extends TestCase
+{
+    /**
+     * @var NodeBuilderInterface
+     */
+    private $nodeBuilder;
+
+    public function setUp()
+    {
+        $this->nodeBuilder = GraphQL::make(NodeBuilderInterface::class);
+    }
+
+    public function testCompareSameNode()
+    {
+        $node = $this->nodeBuilder->build([
+            'kind'  => NodeKindEnum::NAME,
+            'value' => ['kind' => NodeKindEnum::STRING, 'value' => 'Foo'],
+        ]);
+
+        $this->assertTrue(NodeComparator::compare($node, $node));
+    }
+
+    public function testCompareDifferentNode()
+    {
+        $node = $this->nodeBuilder->build([
+            'kind'  => NodeKindEnum::NAME,
+            'value' => ['kind' => NodeKindEnum::STRING, 'value' => 'Foo'],
+        ]);
+
+        $other = $this->nodeBuilder->build([
+            'kind'  => NodeKindEnum::NAME,
+            'value' => ['kind' => NodeKindEnum::STRING, 'value' => 'Bar'],
+        ]);
+
+        $this->assertFalse(NodeComparator::compare($node, $other));
+    }
+}


### PR DESCRIPTION
Introduce visitor info concept to separate the visiting logic from the node logic. Visitor info is immutable so it should reduce the number of potential bugs in the visiting process as well.

This is also something I wanted to do before we start working on the immutable AST and schema directives.