### PR TITLE
Travis CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ php:
   - 7.2
   - 7.3
 
+# Cache Composer packages so "composer install" is faster
+cache:
+  directories:
+  - "$HOME/.composer/cache"
+
 before_script:
   - composer self-update
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 
-# Use container-based infrastructure
-sudo: false
-
 php:
   - 7.1
   - 7.2


### PR DESCRIPTION
Changes proposed in this pull request:
 * `sudo` is no longer required: see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
 * Test the new PHP 7.3
 * Cache Composer packages so `composer install` is faster. Examples, times in seconds:


Build | Set up build cache | composer install | Store build cache | Total | URL
-- | -- | -- | -- | -- | --
No caching | 0 | 26.91 | 0 | 26.91 | https://travis-ci.org/digiaonline/graphql-php/jobs/476821759
With cold cache | 2.74 | 38.69 | 3.46 | 44.89 | https://travis-ci.org/digiaonline/graphql-php/jobs/476823813
With warm cache | 3.59 | 5.02 | 3.54 | 12.15 | https://travis-ci.org/digiaonline/graphql-php/jobs/476825775

